### PR TITLE
Improve include filtering

### DIFF
--- a/common/models/db_models.py
+++ b/common/models/db_models.py
@@ -30,8 +30,7 @@ class EntityHelper(object):
         """
         dictionary = self.to_dict()
         try:
-            if type(includes) is not list:
-                includes = [includes]
+            includes = includes if type(includes) is list else [includes]
             for include in includes:
                 if type(include) is str:
                     related_entity = self.get_related_entity(include)


### PR DESCRIPTION
closes #32 closes #24

I made an error when staging these changes so the commits got mixed up, but it's small enough to just look at files changed instead.

Include filtering now allows any arbitrary combination of includes. However still only one filter per request (#39) 

Examples:
`http://localhost:5000/datafiles?where={"ID":3}&include={"DATASET":"INVESTIGATION"}`
`http://localhost:5000/datafiles?where={"ID":3}&include=["DATAFILEFORMAT", {"DATASET":{"INVESTIGATION":["INVESTIGATIONTYPE","FACILITY"]}}]`
`http://localhost:5000/datafiles?where={"ID":3}&include=["DATASET","DATAFILEFORMAT"]`
`http://localhost:5000/datafiles?where={"ID":3}&include=["DATASET"]`

e.g 
```JavaScript
[
    {
        "ID": "3",
        "CHECKSUM": "None",
        "CREATE_ID": "simple/root",
        "CREATE_TIME": "2019-05-21 11:24:47",
        "DATAFILECREATETIME": "0000-00-00 00:00:00",
        "DATAFILEMODTIME": "0000-00-00 00:00:00",
        "DESCRIPTION": "ut fugit est",
        "DOI": "None",
        "FILESIZE": "846400",
        "LOCATION": "aliquid/aspernatur/eum",
        "MOD_ID": "simple/root",
        "MOD_TIME": "2019-05-21 11:24:47",
        "NAME": "Datafile fdfdo",
        "DATAFILEFORMAT_ID": "1",
        "DATASET_ID": "1",
        "DATAFILEFORMAT": {
            "ID": "1",
            "CREATE_ID": "simple/root",
            "CREATE_TIME": "2019-05-21 11:24:44",
            "DESCRIPTION": "Uploads by the Topcat's users",
            "MOD_ID": "simple/root",
            "MOD_TIME": "2019-05-21 11:24:44",
            "NAME": "upload",
            "TYPE": "misc",
            "VERSION": "1",
            "FACILITY_ID": "1"
        },
        "DATASET": {
            "ID": "1",
            "COMPLETE": "0",
            "CREATE_ID": "simple/root",
            "CREATE_TIME": "2019-05-21 11:24:46",
            "DESCRIPTION": "Test",
            "DOI": "None",
            "END_DATE": "None",
            "LOCATION": "None",
            "MOD_ID": "simple/root",
            "MOD_TIME": "2019-05-21 11:24:46",
            "NAME": "Dataset 1",
            "STARTDATE": "None",
            "INVESTIGATION_ID": "1",
            "SAMPLE_ID": "None",
            "TYPE_ID": "20",
            "INVESTIGATION": {
                "ID": "1",
                "CREATE_ID": "simple/root",
                "CREATE_TIME": "2019-05-21 11:24:46",
                "DOI": "None",
                "ENDDATE": "2017-07-21 12:01:54",
                "MOD_ID": "simple/root",
                "MOD_TIME": "2019-05-21 11:24:46",
                "NAME": "Proposal 1",
                "RELEASEDATE": "None",
                "STARTDATE": "2017-07-13 12:01:54",
                "SUMMARY": "None",
                "TITLE": "quas accusantium omnis",
                "VISIT_ID": "Proposal 1 - 1",
                "FACILITY_ID": "1",
                "TYPE_ID": "16",
                "INVESTIGATIONTYPE": {
                    "ID": "16",
                    "CREATE_ID": "simple/root",
                    "CREATE_TIME": "2019-05-21 11:24:43",
                    "DESCRIPTION": "incidunt enim impedit",
                    "MOD_ID": "simple/root",
                    "MOD_TIME": "2019-05-21 11:24:43",
                    "NAME": "InvestigationType 5",
                    "FACILITY_ID": "1"
                },
                "FACILITY": {
                    "ID": "1",
                    "CREATE_ID": "simple/root",
                    "CREATE_TIME": "2019-05-21 11:24:41",
                    "DAYSUNTILRELEASE": "None",
                    "DESCRIPTION": "None",
                    "FULLNAME": "Lorum Ipsum Light Source",
                    "MOD_ID": "simple/root",
                    "MOD_TIME": "2019-05-21 11:24:41",
                    "NAME": "LILS",
                    "URL": "None"
                }
            }
        }
    }
]
```

All of these return properly and this PR will make #38 easier once merged in