### PR TITLE
Handle trailing slashes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -49,6 +49,7 @@ from src.swagger.swagger_generator import swagger_gen
 swagger_gen.write_swagger_spec()
 
 app = Flask(__name__)
+app.url_map.strict_slashes = False
 api = Api(app)
 
 setup_logger()


### PR DESCRIPTION
closes #59

allows e.g. `/datafiles` and `/datafiles/` 

Query params work on both and works with IDs to e.g

`/datafiles/1` and `/datafiles/1/`