### PR TITLE
Correct response types

### DIFF
--- a/common/models/db_models.py
+++ b/common/models/db_models.py
@@ -2,7 +2,7 @@ import enum
 
 from datetime import datetime
 from sqlalchemy import Index, Column, BigInteger, String, DateTime, ForeignKey, Integer, Float, FetchedValue, \
-    TypeDecorator
+    TypeDecorator, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.collections import InstrumentedList
@@ -320,7 +320,7 @@ class DATASET(Base, EntityHelper):
     )
 
     ID = Column(BigInteger, primary_key=True)
-    COMPLETE = Column(Integer, nullable=False, server_default=FetchedValue())
+    COMPLETE = Column(Boolean, nullable=False, server_default=FetchedValue())
     CREATE_ID = Column(String(255), nullable=False)
     CREATE_TIME = Column(DateTime, nullable=False)
     DESCRIPTION = Column(String(255))
@@ -642,15 +642,15 @@ class PARAMETERTYPE(Base, EntityHelper):
         STRING = 2
 
     ID = Column(BigInteger, primary_key=True)
-    APPLICABLETODATACOLLECTION = Column(Integer, server_default=FetchedValue())
-    APPLICABLETODATAFILE = Column(Integer, server_default=FetchedValue())
-    APPLICABLETODATASET = Column(Integer, server_default=FetchedValue())
-    APPLICABLETOINVESTIGATION = Column(Integer, server_default=FetchedValue())
-    APPLICABLETOSAMPLE = Column(Integer, server_default=FetchedValue())
+    APPLICABLETODATACOLLECTION = Column(Boolean, server_default=FetchedValue())
+    APPLICABLETODATAFILE = Column(Boolean, server_default=FetchedValue())
+    APPLICABLETODATASET = Column(Boolean, server_default=FetchedValue())
+    APPLICABLETOINVESTIGATION = Column(Boolean, server_default=FetchedValue())
+    APPLICABLETOSAMPLE = Column(Boolean, server_default=FetchedValue())
     CREATE_ID = Column(String(255), nullable=False)
     CREATE_TIME = Column(DateTime, nullable=False)
     DESCRIPTION = Column(String(255))
-    ENFORCED = Column(Integer, server_default=FetchedValue())
+    ENFORCED = Column(Boolean, server_default=FetchedValue())
     MAXIMUMNUMERICVALUE = Column(Float(asdecimal=True))
     MINIMUMNUMERICVALUE = Column(Float(asdecimal=True))
     MOD_ID = Column(String(255), nullable=False)
@@ -659,7 +659,7 @@ class PARAMETERTYPE(Base, EntityHelper):
     UNITS = Column(String(255), nullable=False)
     UNITSFULLNAME = Column(String(255))
     VALUETYPE = Column(EnumAsInteger(ValueTypeEnum), nullable=False)
-    VERIFIED = Column(Integer, server_default=FetchedValue())
+    VERIFIED = Column(Boolean, server_default=FetchedValue())
     FACILITY_ID = Column(ForeignKey('FACILITY.ID'), nullable=False)
 
     FACILITY = relationship('FACILITY', primaryjoin='PARAMETERTYPE.FACILITY_ID == FACILITY.ID',


### PR DESCRIPTION
 closes #89 
Only datetime is converted to string now
e.g.

```JavaScript
{
    "ID": 1,
    "CHECKSUM": "73fa87e2309660700a94abf5e767457c",
    "CREATE_ID": "user",
    "CREATE_TIME": "2019-10-04 20:43:26",
    "DATAFILECREATETIME": "2019-10-04 20:43:26",
    "DATAFILEMODTIME": "2019-10-04 04:53:31",
    "DESCRIPTION": "Brother set line here decide. Agreement structure item several able knowledge return.\nWar top air agent must voice high describe. Rise month shake voice need generation.",
    "DOI": "1-344-97869-X",
    "FILESIZE": 36068250,
    "LOCATION": "/professor/identify/season.jpeg",
    "MOD_ID": "user",
    "MOD_TIME": "2019-10-04 04:53:31",
    "NAME": "Datafile 1",
    "DATAFILEFORMAT_ID": 2,
    "DATASET_ID": 2
}
```