### PR TITLE
Add way to filter included entities

### DIFF
--- a/common/database_helpers.py
+++ b/common/database_helpers.py
@@ -148,6 +148,8 @@ class WhereFilter(QueryFilter):
 
     def __init__(self, field, value, operation):
         self.field = field
+        self.included_field = None
+        self.included_included_field = None
         self._set_filter_fields()
         self.value = value
         self.operation = operation


### PR DESCRIPTION
closes #42 
This seems to work
And the filters are applied as discussed e.g. `/investigationinstruments?where={"INSTRUMENT.ID":{"gte":10}}&include="INSTRUMENT"`