### PR TITLE
Generate 2 datasets

### DIFF
--- a/util/icat_db_generator.py
+++ b/util/icat_db_generator.py
@@ -9,7 +9,6 @@ from faker import Faker
 from common.models import db_models
 from common.session_manager import session_manager
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument("--seed", "-s", dest="seed", help="Provide seed for random and faker", type=int, default=1)
 parser.add_argument("--years", "-y", dest="years", help="Provide number of years to generate", type=int, default=20)
@@ -40,7 +39,7 @@ def get_date_time():
     :return: the datetime
     """
     return faker.date_time_between_dates(datetime_start=datetime.datetime(2000, 10, 4),
-                                  datetime_end=datetime.datetime(2019, 10, 5))
+                                         datetime_end=datetime.datetime(2019, 10, 5))
 
 
 def get_start_date(i):
@@ -161,7 +160,7 @@ class DatasetTypeGenerator(Generator):
 
 class FacilityCycleGenerator(Generator):
     tier = 1
-    amount = 4*YEARS  # This gives 4 per year for 20 years
+    amount = 4 * YEARS  # This gives 4 per year for 20 years
 
     def generate(self):
         self.pool_map(FacilityCycleGenerator.generate_facility_cycle)


### PR DESCRIPTION
closes #100 
Changed to 2 datasets per investigation.
Also reduced the number of files per dataset to 55. This is to improve the speed with double the amount of datasets, but more than 50 for infinite loading.