### PR TITLE
#120 - set username + expiredatetime on POST /session

### DIFF
--- a/src/resources/non_entities/sessions_endpoints.py
+++ b/src/resources/non_entities/sessions_endpoints.py
@@ -20,7 +20,7 @@ class Sessions(Resource):
             return "Bad request", 400
         if request.json["username"] == "user" and request.json["password"] == "password":
             session_id = str(uuid.uuid1())
-            insert_row_into_table(SESSION, SESSION(ID=session_id, USERNAME="datagateway-api/user", EXPIREDATETIME=datetime.datetime.now() + datetime.timedelta(days=1)))
+            insert_row_into_table(SESSION, SESSION(ID=session_id, USERNAME="simple/root", EXPIREDATETIME=datetime.datetime.now() + datetime.timedelta(days=1)))
             return {"sessionID": session_id}, 201
         return "Forbidden", 403
 


### PR DESCRIPTION
This sets the username and expireddatetime fields in ICAT. These are needed so that ICAT doesn't error when performing operations such as session refresh etc. It also has the additional benefit of not adding thousands of rows of session ids to ICAT's SESSION table as ICAT will clean up expired ones.

Closes #120 