### PR TITLE
Improve Logging Throughout Python ICAT Backend

### DIFF
--- a/common/filter_order_handler.py
+++ b/common/filter_order_handler.py
@@ -49,6 +49,7 @@ class FilterOrderHandler(object):
         When there are both limit and skip filters in a request, merge them into the
         limit filter and remove the skip filter from the instance
         """
+        log.info("Merging a PythonICATSkipFilter and PythonICATLimitFilter together")
 
         if any(
             isinstance(icat_filter, PythonICATSkipFilter)
@@ -81,6 +82,7 @@ class FilterOrderHandler(object):
         A reset is required because Python ICAT overwrites (as opposed to appending to
         it) the query's order list every time one is added to the query.
         """
+        log.debug("Resetting result order for the order filter")
 
         if any(
             isinstance(icat_filter, PythonICATOrderFilter)

--- a/common/icat/backend.py
+++ b/common/icat/backend.py
@@ -79,6 +79,7 @@ class PythonICATBackend(Backend):
     @requires_session_id
     @queries_records
     def logout(self, session_id):
+        log.info("Logging out of the Python ICAT client")
         self.client.sessionId = session_id
         return logout_icat_client(self.client)
 

--- a/common/icat/backend.py
+++ b/common/icat/backend.py
@@ -46,6 +46,7 @@ class PythonICATBackend(Backend):
         )
 
     def login(self, credentials):
+        log.info("Logging in to get session ID")
         # Client object is re-created here so session IDs aren't overwritten in the
         # database
         self.client = icat.client.Client(
@@ -65,11 +66,13 @@ class PythonICATBackend(Backend):
 
     @requires_session_id
     def get_session_details(self, session_id):
+        log.info("Getting session details for session: %s", session_id)
         self.client.sessionId = session_id
         return get_session_details_helper(self.client)
 
     @requires_session_id
     def refresh(self, session_id):
+        log.info("Refreshing session: %s", session_id)
         self.client.sessionId = session_id
         return refresh_client_session(self.client)
 

--- a/common/icat/filters.py
+++ b/common/icat/filters.py
@@ -47,7 +47,7 @@ class PythonICATWhereFilter(WhereFilter):
 
         log.debug("ICAT Where Filter: %s", where_filter)
         try:
-            log.info("Adding ICAT where filter to query")
+            log.info("Adding ICAT where filter (for %s) to query", self.value)
             query.addConditions(where_filter)
         except ValueError:
             raise FilterError(
@@ -124,7 +124,7 @@ class PythonICATOrderFilter(OrderFilter):
         log.debug("Result Order: %s", PythonICATOrderFilter.result_order)
 
         try:
-            log.info("Adding order filter")
+            log.info("Adding order filter (for %s)", self.field)
             query.setOrder(PythonICATOrderFilter.result_order)
         except ValueError as e:
             # Typically either invalid attribute(s) or attribute(s) contains 1-many
@@ -165,6 +165,7 @@ def icat_set_limit(query, skip_number, limit_number):
     """
     try:
         query.setLimit((skip_number, limit_number))
+        log.debug("Current limit/skip values assigned to query: %s", query.limit)
     except TypeError as e:
         # Not a two element tuple as managed by Python ICAT's setLimit()
         raise FilterError(e)
@@ -192,6 +193,7 @@ class PythonICATIncludeFilter(IncludeFilter):
         :type field: :class:`str` or :class:`list` or :class:`dict`
         """
         if isinstance(field, str):
+            log.debug("Adding %s to include filter", field)
             self.included_filters.append(field)
         elif isinstance(field, dict):
             for key, value in field.items():

--- a/common/icat/helpers.py
+++ b/common/icat/helpers.py
@@ -481,7 +481,7 @@ def get_facility_cycles_for_instrument(
     """
     # TODO - Add logging
 
-    query_aggregate = "COUNT" if count_query else None
+    query_aggregate = "COUNT:DISTINCT" if count_query else "DISTINCT"
     query = ICATQuery(
         client, "FacilityCycle", aggregate=query_aggregate, isis_endpoint=True
     )
@@ -558,7 +558,7 @@ def get_investigations_for_instrument_in_facility_cycle(
     :type count_query: :class:`bool`
     :return: A list of Investigations that match the query
     """
-    query_aggregate = "COUNT" if count_query else None
+    query_aggregate = "COUNT:DISTINCT" if count_query else "DISTINCT"
     query = ICATQuery(
         client, "Investigation", aggregate=query_aggregate, isis_endpoint=True
     )

--- a/common/icat/helpers.py
+++ b/common/icat/helpers.py
@@ -84,7 +84,6 @@ def logout_icat_client(client):
     :param client: ICAT client containing an authenticated user
     :type client: :class:`icat.client.Client`
     """
-    log.info("Logging out of the Python ICAT client")
     client.logout()
 
 

--- a/common/icat/helpers.py
+++ b/common/icat/helpers.py
@@ -84,7 +84,7 @@ def logout_icat_client(client):
     :param client: ICAT client containing an authenticated user
     :type client: :class:`icat.client.Client`
     """
-
+    log.info("Logging out of the Python ICAT client")
     client.logout()
 
 
@@ -119,6 +119,7 @@ def get_python_icat_entity_name(client, database_table_name, camel_case_output=F
         Python ICAT
     :raises BadRequestError: If the entity cannot be found
     """
+    log.debug("Python ICAT entity name camel case flag: %s", camel_case_output)
 
     if camel_case_output:
         entity_names = getTypeMap(client).keys()
@@ -208,6 +209,8 @@ def get_entity_by_id(
     :return: The record of the specified ID from the given entity
     :raises: MissingRecordError: If Python ICAT cannot find a record of the specified ID
     """
+    log.info("Getting %s of the ID %s", table_name, id_)
+    log.debug("Return related entities set to: %s", return_related_entities)
 
     selected_entity_name = get_python_icat_entity_name(client, table_name)
     # Set query condition for the selected ID
@@ -237,7 +240,7 @@ def delete_entity_by_id(client, table_name, id_):
     :param id_: ID number of the entity to delete
     :type id_: :class:`int`
     """
-
+    log.info("Deleting %s of ID %s", table_name, id_)
     entity_id_data = get_entity_by_id(client, table_name, id_, False)
     client.delete(entity_id_data)
 
@@ -256,6 +259,7 @@ def update_entity_by_id(client, table_name, id_, new_data):
         the specified ID
     :return: The updated record of the specified ID from the given entity
     """
+    log.info("Updating %s of ID %s", table_name, id_)
 
     entity_id_data = get_entity_by_id(
         client, table_name, id_, False, return_related_entities=True
@@ -428,6 +432,7 @@ def create_entities(client, table_name, data):
         )
 
         for attribute_name, value in result.items():
+            log.debug("Preparing data for %s", attribute_name)
             try:
                 entity_info = new_entity.getAttrInfo(client, attribute_name)
                 if entity_info.relType.lower() == "attribute":

--- a/common/icat/helpers.py
+++ b/common/icat/helpers.py
@@ -479,7 +479,7 @@ def get_facility_cycles_for_instrument(
     :type count_query: :class:`bool`
     :return: A list of Facility Cycles that match the query
     """
-    # TODO - Add logging
+    log.info("Getting a list of facility cycles from the specified instrument for ISIS")
 
     query_aggregate = "COUNT:DISTINCT" if count_query else "DISTINCT"
     query = ICATQuery(
@@ -532,6 +532,9 @@ def get_facility_cycles_for_instrument_count(client, instrument_id, filters):
     :type filters: List of specific implementations :class:`QueryFilter`
     :return: The number of Facility Cycles that match the query
     """
+    log.info(
+        "Getting the number of facility cycles from the specified instrument for ISIS"
+    )
     return get_facility_cycles_for_instrument(
         client, instrument_id, filters, count_query=True
     )[0]
@@ -558,6 +561,11 @@ def get_investigations_for_instrument_in_facility_cycle(
     :type count_query: :class:`bool`
     :return: A list of Investigations that match the query
     """
+    log.info(
+        "Getting a list of investigations from the specified instrument and facility"
+        " cycle, for ISIS"
+    )
+
     query_aggregate = "COUNT:DISTINCT" if count_query else "DISTINCT"
     query = ICATQuery(
         client, "Investigation", aggregate=query_aggregate, isis_endpoint=True
@@ -615,6 +623,10 @@ def get_investigations_for_instrument_in_facility_cycle_count(
     :type filters: List of specific implementations :class:`QueryFilter`
     :return: The number of Investigations that match the query
     """
+    log.info(
+        "Getting the number of investigations from the specified instrument and"
+        " facility cycle, for ISIS"
+    )
     return get_investigations_for_instrument_in_facility_cycle(
         client, instrument_id, facilitycycle_id, filters, count_query=True
     )[0]

--- a/common/icat/query.py
+++ b/common/icat/query.py
@@ -39,6 +39,12 @@ class ICATQuery:
         :param includes: List of related entity names to add to the query so related
             entities (and their data) can be returned with the query result
         :type includes: :class:`str` or iterable of :class:`str`
+        :param isis_endpoint: Flag to determine if the instance will be used for an ISIS
+            specific endpoint. These endpoints require the use of the DISTINCT aggregate
+            which is different to the distinct field filter implemented in this API, so
+            this flag prevents code related to the filter from executing (because it
+            doesn't need to be on a DISTINCT aggregate)
+        :type isis_endpoint: :class:`bool`
         :return: Query object from Python ICAT
         :raises PythonICATError: If a ValueError is raised when creating a Query(), 500
             will be returned as a response

--- a/common/icat/query.py
+++ b/common/icat/query.py
@@ -99,6 +99,7 @@ class ICATQuery:
         if self.query.aggregate is not None:
             if "COUNT" in self.query.aggregate:
                 count_query = True
+                log.debug("This ICATQuery is used for COUNT purposes")
 
         if (
             self.query.aggregate == "DISTINCT"

--- a/src/main.py
+++ b/src/main.py
@@ -102,6 +102,12 @@ api.add_resource(
 )
 spec.path(resource=InstrumentsFacilityCyclesInvestigationsCount, api=api)
 
+# Reorder paths (e.g. get, patch, post) so openapi.yaml only changes when there's a
+# change to the Swagger docs, rather than changing on each startup
+for entity_data in spec._paths.values():
+    for endpoint_name in sorted(entity_data.keys()):
+        entity_data.move_to_end(endpoint_name)
+
 openapi_spec_path = Path(__file__).parent / "swagger/openapi.yaml"
 with open(openapi_spec_path, "w") as f:
     f.write(spec.to_yaml())

--- a/src/main.py
+++ b/src/main.py
@@ -55,6 +55,7 @@ swaggerui_blueprint = get_swaggerui_blueprint(
 app.register_blueprint(swaggerui_blueprint, url_prefix="/")
 
 setup_logger()
+log.info("Logging now setup")
 
 initialise_spec(spec)
 
@@ -104,6 +105,7 @@ spec.path(resource=InstrumentsFacilityCyclesInvestigationsCount, api=api)
 
 # Reorder paths (e.g. get, patch, post) so openapi.yaml only changes when there's a
 # change to the Swagger docs, rather than changing on each startup
+log.debug("Reordering OpenAPI docs to alphabetical order")
 for entity_data in spec._paths.values():
     for endpoint_name in sorted(entity_data.keys()):
         entity_data.move_to_end(endpoint_name)

--- a/src/swagger/openapi.yaml
+++ b/src/swagger/openapi.yaml
@@ -1760,31 +1760,24 @@ info:
 openapi: 3.0.3
 paths:
   /applications:
-    post:
-      description: Creates new APPLICATION object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/APPLICATION'
-              - items:
-                  $ref: '#/components/schemas/APPLICATION'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of APPLICATION objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/APPLICATION'
-                - items:
-                    $ref: '#/components/schemas/APPLICATION'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/APPLICATION'
+                type: array
+          description: Success - returns APPLICATION that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -1794,7 +1787,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Applications
+      summary: Get Applications
       tags:
       - Applications
     patch:
@@ -1834,24 +1827,31 @@ paths:
       summary: Update Applications
       tags:
       - Applications
-    get:
-      description: Retrieves a list of APPLICATION objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new APPLICATION object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/APPLICATION'
+              - items:
+                  $ref: '#/components/schemas/APPLICATION'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/APPLICATION'
-                type: array
-          description: Success - returns APPLICATION that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/APPLICATION'
+                - items:
+                    $ref: '#/components/schemas/APPLICATION'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -1861,7 +1861,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Applications
+      summary: Create new Applications
       tags:
       - Applications
   /applications/{id_}:
@@ -1888,6 +1888,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Applications by id
+      tags:
+      - Applications
+    get:
+      description: Retrieves a list of APPLICATION objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APPLICATION'
+          description: Success - the matching APPLICATION
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the APPLICATION matching the given ID
       tags:
       - Applications
     patch:
@@ -1924,34 +1952,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Applications by id
-      tags:
-      - Applications
-    get:
-      description: Retrieves a list of APPLICATION objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APPLICATION'
-          description: Success - the matching APPLICATION
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the APPLICATION matching the given ID
       tags:
       - Applications
   /applications/count:
@@ -2011,31 +2011,24 @@ paths:
       tags:
       - Applications
   /datacollectiondatafiles:
-    post:
-      description: Creates new DATACOLLECTIONDATAFILE object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
-              - items:
-                  $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATACOLLECTIONDATAFILE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
-                - items:
-                    $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
+                type: array
+          description: Success - returns DATACOLLECTIONDATAFILE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2045,7 +2038,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DataCollectionDatafiles
+      summary: Get DataCollectionDatafiles
       tags:
       - DataCollectionDatafiles
     patch:
@@ -2085,24 +2078,31 @@ paths:
       summary: Update DataCollectionDatafiles
       tags:
       - DataCollectionDatafiles
-    get:
-      description: Retrieves a list of DATACOLLECTIONDATAFILE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATACOLLECTIONDATAFILE object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
+              - items:
+                  $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
-                type: array
-          description: Success - returns DATACOLLECTIONDATAFILE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
+                - items:
+                    $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2112,7 +2112,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DataCollectionDatafiles
+      summary: Create new DataCollectionDatafiles
       tags:
       - DataCollectionDatafiles
   /datacollectiondatafiles/{id_}:
@@ -2139,6 +2139,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DataCollectionDatafiles by id
+      tags:
+      - DataCollectionDatafiles
+    get:
+      description: Retrieves a list of DATACOLLECTIONDATAFILE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
+          description: Success - the matching DATACOLLECTIONDATAFILE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATACOLLECTIONDATAFILE matching the given ID
       tags:
       - DataCollectionDatafiles
     patch:
@@ -2175,34 +2203,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DataCollectionDatafiles by id
-      tags:
-      - DataCollectionDatafiles
-    get:
-      description: Retrieves a list of DATACOLLECTIONDATAFILE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATACOLLECTIONDATAFILE'
-          description: Success - the matching DATACOLLECTIONDATAFILE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATACOLLECTIONDATAFILE matching the given ID
       tags:
       - DataCollectionDatafiles
   /datacollectiondatafiles/count:
@@ -2264,31 +2264,24 @@ paths:
       tags:
       - DataCollectionDatafiles
   /datacollectiondatasets:
-    post:
-      description: Creates new DATACOLLECTIONDATASET object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATACOLLECTIONDATASET'
-              - items:
-                  $ref: '#/components/schemas/DATACOLLECTIONDATASET'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATACOLLECTIONDATASET objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATACOLLECTIONDATASET'
-                - items:
-                    $ref: '#/components/schemas/DATACOLLECTIONDATASET'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATACOLLECTIONDATASET'
+                type: array
+          description: Success - returns DATACOLLECTIONDATASET that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2298,7 +2291,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DataCollectionDatasets
+      summary: Get DataCollectionDatasets
       tags:
       - DataCollectionDatasets
     patch:
@@ -2338,24 +2331,31 @@ paths:
       summary: Update DataCollectionDatasets
       tags:
       - DataCollectionDatasets
-    get:
-      description: Retrieves a list of DATACOLLECTIONDATASET objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATACOLLECTIONDATASET object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATACOLLECTIONDATASET'
+              - items:
+                  $ref: '#/components/schemas/DATACOLLECTIONDATASET'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATACOLLECTIONDATASET'
-                type: array
-          description: Success - returns DATACOLLECTIONDATASET that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATACOLLECTIONDATASET'
+                - items:
+                    $ref: '#/components/schemas/DATACOLLECTIONDATASET'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2365,7 +2365,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DataCollectionDatasets
+      summary: Create new DataCollectionDatasets
       tags:
       - DataCollectionDatasets
   /datacollectiondatasets/{id_}:
@@ -2392,6 +2392,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DataCollectionDatasets by id
+      tags:
+      - DataCollectionDatasets
+    get:
+      description: Retrieves a list of DATACOLLECTIONDATASET objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATACOLLECTIONDATASET'
+          description: Success - the matching DATACOLLECTIONDATASET
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATACOLLECTIONDATASET matching the given ID
       tags:
       - DataCollectionDatasets
     patch:
@@ -2428,34 +2456,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DataCollectionDatasets by id
-      tags:
-      - DataCollectionDatasets
-    get:
-      description: Retrieves a list of DATACOLLECTIONDATASET objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATACOLLECTIONDATASET'
-          description: Success - the matching DATACOLLECTIONDATASET
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATACOLLECTIONDATASET matching the given ID
       tags:
       - DataCollectionDatasets
   /datacollectiondatasets/count:
@@ -2517,31 +2517,25 @@ paths:
       tags:
       - DataCollectionDatasets
   /datacollectionparameters:
-    post:
-      description: Creates new DATACOLLECTIONPARAMETER object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
-              - items:
-                  $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATACOLLECTIONPARAMETER objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
-                - items:
-                    $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
+                type: array
+          description: Success - returns DATACOLLECTIONPARAMETER that satisfy the
+            filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2551,7 +2545,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DataCollectionParameters
+      summary: Get DataCollectionParameters
       tags:
       - DataCollectionParameters
     patch:
@@ -2591,25 +2585,31 @@ paths:
       summary: Update DataCollectionParameters
       tags:
       - DataCollectionParameters
-    get:
-      description: Retrieves a list of DATACOLLECTIONPARAMETER objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATACOLLECTIONPARAMETER object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
+              - items:
+                  $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
-                type: array
-          description: Success - returns DATACOLLECTIONPARAMETER that satisfy the
-            filters
+                oneOf:
+                - $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
+                - items:
+                    $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2619,7 +2619,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DataCollectionParameters
+      summary: Create new DataCollectionParameters
       tags:
       - DataCollectionParameters
   /datacollectionparameters/{id_}:
@@ -2646,6 +2646,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DataCollectionParameters by id
+      tags:
+      - DataCollectionParameters
+    get:
+      description: Retrieves a list of DATACOLLECTIONPARAMETER objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
+          description: Success - the matching DATACOLLECTIONPARAMETER
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATACOLLECTIONPARAMETER matching the given ID
       tags:
       - DataCollectionParameters
     patch:
@@ -2682,34 +2710,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DataCollectionParameters by id
-      tags:
-      - DataCollectionParameters
-    get:
-      description: Retrieves a list of DATACOLLECTIONPARAMETER objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATACOLLECTIONPARAMETER'
-          description: Success - the matching DATACOLLECTIONPARAMETER
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATACOLLECTIONPARAMETER matching the given ID
       tags:
       - DataCollectionParameters
   /datacollectionparameters/count:
@@ -2771,31 +2771,24 @@ paths:
       tags:
       - DataCollectionParameters
   /datacollections:
-    post:
-      description: Creates new DATACOLLECTION object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATACOLLECTION'
-              - items:
-                  $ref: '#/components/schemas/DATACOLLECTION'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATACOLLECTION objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATACOLLECTION'
-                - items:
-                    $ref: '#/components/schemas/DATACOLLECTION'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATACOLLECTION'
+                type: array
+          description: Success - returns DATACOLLECTION that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2805,7 +2798,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DataCollections
+      summary: Get DataCollections
       tags:
       - DataCollections
     patch:
@@ -2845,24 +2838,31 @@ paths:
       summary: Update DataCollections
       tags:
       - DataCollections
-    get:
-      description: Retrieves a list of DATACOLLECTION objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATACOLLECTION object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATACOLLECTION'
+              - items:
+                  $ref: '#/components/schemas/DATACOLLECTION'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATACOLLECTION'
-                type: array
-          description: Success - returns DATACOLLECTION that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATACOLLECTION'
+                - items:
+                    $ref: '#/components/schemas/DATACOLLECTION'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -2872,7 +2872,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DataCollections
+      summary: Create new DataCollections
       tags:
       - DataCollections
   /datacollections/{id_}:
@@ -2899,6 +2899,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DataCollections by id
+      tags:
+      - DataCollections
+    get:
+      description: Retrieves a list of DATACOLLECTION objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATACOLLECTION'
+          description: Success - the matching DATACOLLECTION
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATACOLLECTION matching the given ID
       tags:
       - DataCollections
     patch:
@@ -2935,34 +2963,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DataCollections by id
-      tags:
-      - DataCollections
-    get:
-      description: Retrieves a list of DATACOLLECTION objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATACOLLECTION'
-          description: Success - the matching DATACOLLECTION
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATACOLLECTION matching the given ID
       tags:
       - DataCollections
   /datacollections/count:
@@ -3022,31 +3022,24 @@ paths:
       tags:
       - DataCollections
   /datafileformats:
-    post:
-      description: Creates new DATAFILEFORMAT object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATAFILEFORMAT'
-              - items:
-                  $ref: '#/components/schemas/DATAFILEFORMAT'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATAFILEFORMAT objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATAFILEFORMAT'
-                - items:
-                    $ref: '#/components/schemas/DATAFILEFORMAT'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATAFILEFORMAT'
+                type: array
+          description: Success - returns DATAFILEFORMAT that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3056,7 +3049,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DatafileFormats
+      summary: Get DatafileFormats
       tags:
       - DatafileFormats
     patch:
@@ -3096,24 +3089,31 @@ paths:
       summary: Update DatafileFormats
       tags:
       - DatafileFormats
-    get:
-      description: Retrieves a list of DATAFILEFORMAT objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATAFILEFORMAT object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATAFILEFORMAT'
+              - items:
+                  $ref: '#/components/schemas/DATAFILEFORMAT'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATAFILEFORMAT'
-                type: array
-          description: Success - returns DATAFILEFORMAT that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATAFILEFORMAT'
+                - items:
+                    $ref: '#/components/schemas/DATAFILEFORMAT'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3123,7 +3123,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DatafileFormats
+      summary: Create new DatafileFormats
       tags:
       - DatafileFormats
   /datafileformats/{id_}:
@@ -3150,6 +3150,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DatafileFormats by id
+      tags:
+      - DatafileFormats
+    get:
+      description: Retrieves a list of DATAFILEFORMAT objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATAFILEFORMAT'
+          description: Success - the matching DATAFILEFORMAT
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATAFILEFORMAT matching the given ID
       tags:
       - DatafileFormats
     patch:
@@ -3186,34 +3214,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DatafileFormats by id
-      tags:
-      - DatafileFormats
-    get:
-      description: Retrieves a list of DATAFILEFORMAT objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATAFILEFORMAT'
-          description: Success - the matching DATAFILEFORMAT
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATAFILEFORMAT matching the given ID
       tags:
       - DatafileFormats
   /datafileformats/count:
@@ -3273,31 +3273,24 @@ paths:
       tags:
       - DatafileFormats
   /datafileparameters:
-    post:
-      description: Creates new DATAFILEPARAMETER object(s) with details provided in
-        the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATAFILEPARAMETER'
-              - items:
-                  $ref: '#/components/schemas/DATAFILEPARAMETER'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATAFILEPARAMETER objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATAFILEPARAMETER'
-                - items:
-                    $ref: '#/components/schemas/DATAFILEPARAMETER'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATAFILEPARAMETER'
+                type: array
+          description: Success - returns DATAFILEPARAMETER that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3307,7 +3300,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DatafileParameters
+      summary: Get DatafileParameters
       tags:
       - DatafileParameters
     patch:
@@ -3347,24 +3340,31 @@ paths:
       summary: Update DatafileParameters
       tags:
       - DatafileParameters
-    get:
-      description: Retrieves a list of DATAFILEPARAMETER objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATAFILEPARAMETER object(s) with details provided in
+        the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATAFILEPARAMETER'
+              - items:
+                  $ref: '#/components/schemas/DATAFILEPARAMETER'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATAFILEPARAMETER'
-                type: array
-          description: Success - returns DATAFILEPARAMETER that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATAFILEPARAMETER'
+                - items:
+                    $ref: '#/components/schemas/DATAFILEPARAMETER'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3374,7 +3374,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DatafileParameters
+      summary: Create new DatafileParameters
       tags:
       - DatafileParameters
   /datafileparameters/{id_}:
@@ -3401,6 +3401,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DatafileParameters by id
+      tags:
+      - DatafileParameters
+    get:
+      description: Retrieves a list of DATAFILEPARAMETER objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATAFILEPARAMETER'
+          description: Success - the matching DATAFILEPARAMETER
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATAFILEPARAMETER matching the given ID
       tags:
       - DatafileParameters
     patch:
@@ -3437,34 +3465,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DatafileParameters by id
-      tags:
-      - DatafileParameters
-    get:
-      description: Retrieves a list of DATAFILEPARAMETER objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATAFILEPARAMETER'
-          description: Success - the matching DATAFILEPARAMETER
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATAFILEPARAMETER matching the given ID
       tags:
       - DatafileParameters
   /datafileparameters/count:
@@ -3525,31 +3525,24 @@ paths:
       tags:
       - DatafileParameters
   /datafiles:
-    post:
-      description: Creates new DATAFILE object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATAFILE'
-              - items:
-                  $ref: '#/components/schemas/DATAFILE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATAFILE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATAFILE'
-                - items:
-                    $ref: '#/components/schemas/DATAFILE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATAFILE'
+                type: array
+          description: Success - returns DATAFILE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3559,7 +3552,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Datafiles
+      summary: Get Datafiles
       tags:
       - Datafiles
     patch:
@@ -3599,24 +3592,31 @@ paths:
       summary: Update Datafiles
       tags:
       - Datafiles
-    get:
-      description: Retrieves a list of DATAFILE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATAFILE object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATAFILE'
+              - items:
+                  $ref: '#/components/schemas/DATAFILE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATAFILE'
-                type: array
-          description: Success - returns DATAFILE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATAFILE'
+                - items:
+                    $ref: '#/components/schemas/DATAFILE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3626,7 +3626,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Datafiles
+      summary: Create new Datafiles
       tags:
       - Datafiles
   /datafiles/{id_}:
@@ -3653,6 +3653,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Datafiles by id
+      tags:
+      - Datafiles
+    get:
+      description: Retrieves a list of DATAFILE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATAFILE'
+          description: Success - the matching DATAFILE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATAFILE matching the given ID
       tags:
       - Datafiles
     patch:
@@ -3689,34 +3717,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Datafiles by id
-      tags:
-      - Datafiles
-    get:
-      description: Retrieves a list of DATAFILE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATAFILE'
-          description: Success - the matching DATAFILE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATAFILE matching the given ID
       tags:
       - Datafiles
   /datafiles/count:
@@ -3776,31 +3776,24 @@ paths:
       tags:
       - Datafiles
   /datasetparameters:
-    post:
-      description: Creates new DATASETPARAMETER object(s) with details provided in
-        the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATASETPARAMETER'
-              - items:
-                  $ref: '#/components/schemas/DATASETPARAMETER'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATASETPARAMETER objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATASETPARAMETER'
-                - items:
-                    $ref: '#/components/schemas/DATASETPARAMETER'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATASETPARAMETER'
+                type: array
+          description: Success - returns DATASETPARAMETER that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3810,7 +3803,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DatasetParameters
+      summary: Get DatasetParameters
       tags:
       - DatasetParameters
     patch:
@@ -3850,24 +3843,31 @@ paths:
       summary: Update DatasetParameters
       tags:
       - DatasetParameters
-    get:
-      description: Retrieves a list of DATASETPARAMETER objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATASETPARAMETER object(s) with details provided in
+        the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATASETPARAMETER'
+              - items:
+                  $ref: '#/components/schemas/DATASETPARAMETER'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATASETPARAMETER'
-                type: array
-          description: Success - returns DATASETPARAMETER that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATASETPARAMETER'
+                - items:
+                    $ref: '#/components/schemas/DATASETPARAMETER'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -3877,7 +3877,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DatasetParameters
+      summary: Create new DatasetParameters
       tags:
       - DatasetParameters
   /datasetparameters/{id_}:
@@ -3904,6 +3904,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DatasetParameters by id
+      tags:
+      - DatasetParameters
+    get:
+      description: Retrieves a list of DATASETPARAMETER objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATASETPARAMETER'
+          description: Success - the matching DATASETPARAMETER
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATASETPARAMETER matching the given ID
       tags:
       - DatasetParameters
     patch:
@@ -3940,34 +3968,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DatasetParameters by id
-      tags:
-      - DatasetParameters
-    get:
-      description: Retrieves a list of DATASETPARAMETER objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATASETPARAMETER'
-          description: Success - the matching DATASETPARAMETER
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATASETPARAMETER matching the given ID
       tags:
       - DatasetParameters
   /datasetparameters/count:
@@ -4028,31 +4028,24 @@ paths:
       tags:
       - DatasetParameters
   /datasettypes:
-    post:
-      description: Creates new DATASETTYPE object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATASETTYPE'
-              - items:
-                  $ref: '#/components/schemas/DATASETTYPE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATASETTYPE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATASETTYPE'
-                - items:
-                    $ref: '#/components/schemas/DATASETTYPE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATASETTYPE'
+                type: array
+          description: Success - returns DATASETTYPE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4062,7 +4055,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new DatasetTypes
+      summary: Get DatasetTypes
       tags:
       - DatasetTypes
     patch:
@@ -4102,24 +4095,31 @@ paths:
       summary: Update DatasetTypes
       tags:
       - DatasetTypes
-    get:
-      description: Retrieves a list of DATASETTYPE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATASETTYPE object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATASETTYPE'
+              - items:
+                  $ref: '#/components/schemas/DATASETTYPE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATASETTYPE'
-                type: array
-          description: Success - returns DATASETTYPE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATASETTYPE'
+                - items:
+                    $ref: '#/components/schemas/DATASETTYPE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4129,7 +4129,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get DatasetTypes
+      summary: Create new DatasetTypes
       tags:
       - DatasetTypes
   /datasettypes/{id_}:
@@ -4156,6 +4156,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete DatasetTypes by id
+      tags:
+      - DatasetTypes
+    get:
+      description: Retrieves a list of DATASETTYPE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATASETTYPE'
+          description: Success - the matching DATASETTYPE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATASETTYPE matching the given ID
       tags:
       - DatasetTypes
     patch:
@@ -4192,34 +4220,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update DatasetTypes by id
-      tags:
-      - DatasetTypes
-    get:
-      description: Retrieves a list of DATASETTYPE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATASETTYPE'
-          description: Success - the matching DATASETTYPE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATASETTYPE matching the given ID
       tags:
       - DatasetTypes
   /datasettypes/count:
@@ -4279,31 +4279,24 @@ paths:
       tags:
       - DatasetTypes
   /datasets:
-    post:
-      description: Creates new DATASET object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/DATASET'
-              - items:
-                  $ref: '#/components/schemas/DATASET'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of DATASET objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/DATASET'
-                - items:
-                    $ref: '#/components/schemas/DATASET'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/DATASET'
+                type: array
+          description: Success - returns DATASET that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4313,7 +4306,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Datasets
+      summary: Get Datasets
       tags:
       - Datasets
     patch:
@@ -4353,24 +4346,31 @@ paths:
       summary: Update Datasets
       tags:
       - Datasets
-    get:
-      description: Retrieves a list of DATASET objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new DATASET object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/DATASET'
+              - items:
+                  $ref: '#/components/schemas/DATASET'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/DATASET'
-                type: array
-          description: Success - returns DATASET that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/DATASET'
+                - items:
+                    $ref: '#/components/schemas/DATASET'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4380,7 +4380,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Datasets
+      summary: Create new Datasets
       tags:
       - Datasets
   /datasets/{id_}:
@@ -4407,6 +4407,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Datasets by id
+      tags:
+      - Datasets
+    get:
+      description: Retrieves a list of DATASET objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DATASET'
+          description: Success - the matching DATASET
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the DATASET matching the given ID
       tags:
       - Datasets
     patch:
@@ -4443,34 +4471,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Datasets by id
-      tags:
-      - Datasets
-    get:
-      description: Retrieves a list of DATASET objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DATASET'
-          description: Success - the matching DATASET
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the DATASET matching the given ID
       tags:
       - Datasets
   /datasets/count:
@@ -4530,31 +4530,24 @@ paths:
       tags:
       - Datasets
   /facilities:
-    post:
-      description: Creates new FACILITY object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/FACILITY'
-              - items:
-                  $ref: '#/components/schemas/FACILITY'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of FACILITY objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/FACILITY'
-                - items:
-                    $ref: '#/components/schemas/FACILITY'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/FACILITY'
+                type: array
+          description: Success - returns FACILITY that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4564,7 +4557,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Facilities
+      summary: Get Facilities
       tags:
       - Facilities
     patch:
@@ -4604,24 +4597,31 @@ paths:
       summary: Update Facilities
       tags:
       - Facilities
-    get:
-      description: Retrieves a list of FACILITY objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new FACILITY object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/FACILITY'
+              - items:
+                  $ref: '#/components/schemas/FACILITY'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/FACILITY'
-                type: array
-          description: Success - returns FACILITY that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/FACILITY'
+                - items:
+                    $ref: '#/components/schemas/FACILITY'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4631,7 +4631,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Facilities
+      summary: Create new Facilities
       tags:
       - Facilities
   /facilities/{id_}:
@@ -4658,6 +4658,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Facilities by id
+      tags:
+      - Facilities
+    get:
+      description: Retrieves a list of FACILITY objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FACILITY'
+          description: Success - the matching FACILITY
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the FACILITY matching the given ID
       tags:
       - Facilities
     patch:
@@ -4694,34 +4722,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Facilities by id
-      tags:
-      - Facilities
-    get:
-      description: Retrieves a list of FACILITY objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FACILITY'
-          description: Success - the matching FACILITY
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the FACILITY matching the given ID
       tags:
       - Facilities
   /facilities/count:
@@ -4781,31 +4781,24 @@ paths:
       tags:
       - Facilities
   /facilitycycles:
-    post:
-      description: Creates new FACILITYCYCLE object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/FACILITYCYCLE'
-              - items:
-                  $ref: '#/components/schemas/FACILITYCYCLE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of FACILITYCYCLE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/FACILITYCYCLE'
-                - items:
-                    $ref: '#/components/schemas/FACILITYCYCLE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/FACILITYCYCLE'
+                type: array
+          description: Success - returns FACILITYCYCLE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4815,7 +4808,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new FacilityCycles
+      summary: Get FacilityCycles
       tags:
       - FacilityCycles
     patch:
@@ -4855,24 +4848,31 @@ paths:
       summary: Update FacilityCycles
       tags:
       - FacilityCycles
-    get:
-      description: Retrieves a list of FACILITYCYCLE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new FACILITYCYCLE object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/FACILITYCYCLE'
+              - items:
+                  $ref: '#/components/schemas/FACILITYCYCLE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/FACILITYCYCLE'
-                type: array
-          description: Success - returns FACILITYCYCLE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/FACILITYCYCLE'
+                - items:
+                    $ref: '#/components/schemas/FACILITYCYCLE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -4882,7 +4882,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get FacilityCycles
+      summary: Create new FacilityCycles
       tags:
       - FacilityCycles
   /facilitycycles/{id_}:
@@ -4909,6 +4909,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete FacilityCycles by id
+      tags:
+      - FacilityCycles
+    get:
+      description: Retrieves a list of FACILITYCYCLE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FACILITYCYCLE'
+          description: Success - the matching FACILITYCYCLE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the FACILITYCYCLE matching the given ID
       tags:
       - FacilityCycles
     patch:
@@ -4945,34 +4973,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update FacilityCycles by id
-      tags:
-      - FacilityCycles
-    get:
-      description: Retrieves a list of FACILITYCYCLE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FACILITYCYCLE'
-          description: Success - the matching FACILITYCYCLE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the FACILITYCYCLE matching the given ID
       tags:
       - FacilityCycles
   /facilitycycles/count:
@@ -5032,31 +5032,24 @@ paths:
       tags:
       - FacilityCycles
   /groupings:
-    post:
-      description: Creates new GROUPING object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/GROUPING'
-              - items:
-                  $ref: '#/components/schemas/GROUPING'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of GROUPING objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/GROUPING'
-                - items:
-                    $ref: '#/components/schemas/GROUPING'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/GROUPING'
+                type: array
+          description: Success - returns GROUPING that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5066,7 +5059,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Groupings
+      summary: Get Groupings
       tags:
       - Groupings
     patch:
@@ -5106,24 +5099,31 @@ paths:
       summary: Update Groupings
       tags:
       - Groupings
-    get:
-      description: Retrieves a list of GROUPING objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new GROUPING object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/GROUPING'
+              - items:
+                  $ref: '#/components/schemas/GROUPING'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/GROUPING'
-                type: array
-          description: Success - returns GROUPING that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/GROUPING'
+                - items:
+                    $ref: '#/components/schemas/GROUPING'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5133,7 +5133,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Groupings
+      summary: Create new Groupings
       tags:
       - Groupings
   /groupings/{id_}:
@@ -5160,6 +5160,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Groupings by id
+      tags:
+      - Groupings
+    get:
+      description: Retrieves a list of GROUPING objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GROUPING'
+          description: Success - the matching GROUPING
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the GROUPING matching the given ID
       tags:
       - Groupings
     patch:
@@ -5196,34 +5224,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Groupings by id
-      tags:
-      - Groupings
-    get:
-      description: Retrieves a list of GROUPING objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GROUPING'
-          description: Success - the matching GROUPING
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the GROUPING matching the given ID
       tags:
       - Groupings
   /groupings/count:
@@ -5283,31 +5283,24 @@ paths:
       tags:
       - Groupings
   /instrumentscientists:
-    post:
-      description: Creates new INSTRUMENTSCIENTIST object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
-              - items:
-                  $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INSTRUMENTSCIENTIST objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
-                - items:
-                    $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
+                type: array
+          description: Success - returns INSTRUMENTSCIENTIST that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5317,7 +5310,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new InstrumentScientists
+      summary: Get InstrumentScientists
       tags:
       - InstrumentScientists
     patch:
@@ -5357,24 +5350,31 @@ paths:
       summary: Update InstrumentScientists
       tags:
       - InstrumentScientists
-    get:
-      description: Retrieves a list of INSTRUMENTSCIENTIST objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INSTRUMENTSCIENTIST object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
+              - items:
+                  $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
-                type: array
-          description: Success - returns INSTRUMENTSCIENTIST that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
+                - items:
+                    $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5384,7 +5384,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get InstrumentScientists
+      summary: Create new InstrumentScientists
       tags:
       - InstrumentScientists
   /instrumentscientists/{id_}:
@@ -5411,6 +5411,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete InstrumentScientists by id
+      tags:
+      - InstrumentScientists
+    get:
+      description: Retrieves a list of INSTRUMENTSCIENTIST objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
+          description: Success - the matching INSTRUMENTSCIENTIST
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INSTRUMENTSCIENTIST matching the given ID
       tags:
       - InstrumentScientists
     patch:
@@ -5447,34 +5475,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update InstrumentScientists by id
-      tags:
-      - InstrumentScientists
-    get:
-      description: Retrieves a list of INSTRUMENTSCIENTIST objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INSTRUMENTSCIENTIST'
-          description: Success - the matching INSTRUMENTSCIENTIST
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INSTRUMENTSCIENTIST matching the given ID
       tags:
       - InstrumentScientists
   /instrumentscientists/count:
@@ -5535,31 +5535,24 @@ paths:
       tags:
       - InstrumentScientists
   /instruments:
-    post:
-      description: Creates new INSTRUMENT object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INSTRUMENT'
-              - items:
-                  $ref: '#/components/schemas/INSTRUMENT'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INSTRUMENT objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INSTRUMENT'
-                - items:
-                    $ref: '#/components/schemas/INSTRUMENT'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INSTRUMENT'
+                type: array
+          description: Success - returns INSTRUMENT that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5569,7 +5562,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Instruments
+      summary: Get Instruments
       tags:
       - Instruments
     patch:
@@ -5609,24 +5602,31 @@ paths:
       summary: Update Instruments
       tags:
       - Instruments
-    get:
-      description: Retrieves a list of INSTRUMENT objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INSTRUMENT object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INSTRUMENT'
+              - items:
+                  $ref: '#/components/schemas/INSTRUMENT'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INSTRUMENT'
-                type: array
-          description: Success - returns INSTRUMENT that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/INSTRUMENT'
+                - items:
+                    $ref: '#/components/schemas/INSTRUMENT'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5636,7 +5636,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Instruments
+      summary: Create new Instruments
       tags:
       - Instruments
   /instruments/{id_}:
@@ -5663,6 +5663,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Instruments by id
+      tags:
+      - Instruments
+    get:
+      description: Retrieves a list of INSTRUMENT objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INSTRUMENT'
+          description: Success - the matching INSTRUMENT
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INSTRUMENT matching the given ID
       tags:
       - Instruments
     patch:
@@ -5699,34 +5727,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Instruments by id
-      tags:
-      - Instruments
-    get:
-      description: Retrieves a list of INSTRUMENT objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INSTRUMENT'
-          description: Success - the matching INSTRUMENT
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INSTRUMENT matching the given ID
       tags:
       - Instruments
   /instruments/count:
@@ -5786,31 +5786,24 @@ paths:
       tags:
       - Instruments
   /investigationgroups:
-    post:
-      description: Creates new INVESTIGATIONGROUP object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INVESTIGATIONGROUP'
-              - items:
-                  $ref: '#/components/schemas/INVESTIGATIONGROUP'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INVESTIGATIONGROUP objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INVESTIGATIONGROUP'
-                - items:
-                    $ref: '#/components/schemas/INVESTIGATIONGROUP'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INVESTIGATIONGROUP'
+                type: array
+          description: Success - returns INVESTIGATIONGROUP that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5820,7 +5813,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new InvestigationGroups
+      summary: Get InvestigationGroups
       tags:
       - InvestigationGroups
     patch:
@@ -5860,24 +5853,31 @@ paths:
       summary: Update InvestigationGroups
       tags:
       - InvestigationGroups
-    get:
-      description: Retrieves a list of INVESTIGATIONGROUP objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INVESTIGATIONGROUP object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INVESTIGATIONGROUP'
+              - items:
+                  $ref: '#/components/schemas/INVESTIGATIONGROUP'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INVESTIGATIONGROUP'
-                type: array
-          description: Success - returns INVESTIGATIONGROUP that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/INVESTIGATIONGROUP'
+                - items:
+                    $ref: '#/components/schemas/INVESTIGATIONGROUP'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -5887,7 +5887,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get InvestigationGroups
+      summary: Create new InvestigationGroups
       tags:
       - InvestigationGroups
   /investigationgroups/{id_}:
@@ -5914,6 +5914,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete InvestigationGroups by id
+      tags:
+      - InvestigationGroups
+    get:
+      description: Retrieves a list of INVESTIGATIONGROUP objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INVESTIGATIONGROUP'
+          description: Success - the matching INVESTIGATIONGROUP
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INVESTIGATIONGROUP matching the given ID
       tags:
       - InvestigationGroups
     patch:
@@ -5950,34 +5978,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update InvestigationGroups by id
-      tags:
-      - InvestigationGroups
-    get:
-      description: Retrieves a list of INVESTIGATIONGROUP objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INVESTIGATIONGROUP'
-          description: Success - the matching INVESTIGATIONGROUP
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INVESTIGATIONGROUP matching the given ID
       tags:
       - InvestigationGroups
   /investigationgroups/count:
@@ -6038,31 +6038,25 @@ paths:
       tags:
       - InvestigationGroups
   /investigationinstruments:
-    post:
-      description: Creates new INVESTIGATIONINSTRUMENT object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
-              - items:
-                  $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INVESTIGATIONINSTRUMENT objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
-                - items:
-                    $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
+                type: array
+          description: Success - returns INVESTIGATIONINSTRUMENT that satisfy the
+            filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6072,7 +6066,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new InvestigationInstruments
+      summary: Get InvestigationInstruments
       tags:
       - InvestigationInstruments
     patch:
@@ -6112,25 +6106,31 @@ paths:
       summary: Update InvestigationInstruments
       tags:
       - InvestigationInstruments
-    get:
-      description: Retrieves a list of INVESTIGATIONINSTRUMENT objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INVESTIGATIONINSTRUMENT object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
+              - items:
+                  $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
-                type: array
-          description: Success - returns INVESTIGATIONINSTRUMENT that satisfy the
-            filters
+                oneOf:
+                - $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
+                - items:
+                    $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6140,7 +6140,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get InvestigationInstruments
+      summary: Create new InvestigationInstruments
       tags:
       - InvestigationInstruments
   /investigationinstruments/{id_}:
@@ -6167,6 +6167,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete InvestigationInstruments by id
+      tags:
+      - InvestigationInstruments
+    get:
+      description: Retrieves a list of INVESTIGATIONINSTRUMENT objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
+          description: Success - the matching INVESTIGATIONINSTRUMENT
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INVESTIGATIONINSTRUMENT matching the given ID
       tags:
       - InvestigationInstruments
     patch:
@@ -6203,34 +6231,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update InvestigationInstruments by id
-      tags:
-      - InvestigationInstruments
-    get:
-      description: Retrieves a list of INVESTIGATIONINSTRUMENT objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INVESTIGATIONINSTRUMENT'
-          description: Success - the matching INVESTIGATIONINSTRUMENT
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INVESTIGATIONINSTRUMENT matching the given ID
       tags:
       - InvestigationInstruments
   /investigationinstruments/count:
@@ -6292,31 +6292,24 @@ paths:
       tags:
       - InvestigationInstruments
   /investigationparameters:
-    post:
-      description: Creates new INVESTIGATIONPARAMETER object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
-              - items:
-                  $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INVESTIGATIONPARAMETER objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
-                - items:
-                    $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
+                type: array
+          description: Success - returns INVESTIGATIONPARAMETER that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6326,7 +6319,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new InvestigationParameters
+      summary: Get InvestigationParameters
       tags:
       - InvestigationParameters
     patch:
@@ -6366,24 +6359,31 @@ paths:
       summary: Update InvestigationParameters
       tags:
       - InvestigationParameters
-    get:
-      description: Retrieves a list of INVESTIGATIONPARAMETER objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INVESTIGATIONPARAMETER object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
+              - items:
+                  $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
-                type: array
-          description: Success - returns INVESTIGATIONPARAMETER that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
+                - items:
+                    $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6393,7 +6393,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get InvestigationParameters
+      summary: Create new InvestigationParameters
       tags:
       - InvestigationParameters
   /investigationparameters/{id_}:
@@ -6420,6 +6420,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete InvestigationParameters by id
+      tags:
+      - InvestigationParameters
+    get:
+      description: Retrieves a list of INVESTIGATIONPARAMETER objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
+          description: Success - the matching INVESTIGATIONPARAMETER
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INVESTIGATIONPARAMETER matching the given ID
       tags:
       - InvestigationParameters
     patch:
@@ -6456,34 +6484,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update InvestigationParameters by id
-      tags:
-      - InvestigationParameters
-    get:
-      description: Retrieves a list of INVESTIGATIONPARAMETER objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INVESTIGATIONPARAMETER'
-          description: Success - the matching INVESTIGATIONPARAMETER
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INVESTIGATIONPARAMETER matching the given ID
       tags:
       - InvestigationParameters
   /investigationparameters/count:
@@ -6545,31 +6545,24 @@ paths:
       tags:
       - InvestigationParameters
   /investigationtypes:
-    post:
-      description: Creates new INVESTIGATIONTYPE object(s) with details provided in
-        the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INVESTIGATIONTYPE'
-              - items:
-                  $ref: '#/components/schemas/INVESTIGATIONTYPE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INVESTIGATIONTYPE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INVESTIGATIONTYPE'
-                - items:
-                    $ref: '#/components/schemas/INVESTIGATIONTYPE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INVESTIGATIONTYPE'
+                type: array
+          description: Success - returns INVESTIGATIONTYPE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6579,7 +6572,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new InvestigationTypes
+      summary: Get InvestigationTypes
       tags:
       - InvestigationTypes
     patch:
@@ -6619,24 +6612,31 @@ paths:
       summary: Update InvestigationTypes
       tags:
       - InvestigationTypes
-    get:
-      description: Retrieves a list of INVESTIGATIONTYPE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INVESTIGATIONTYPE object(s) with details provided in
+        the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INVESTIGATIONTYPE'
+              - items:
+                  $ref: '#/components/schemas/INVESTIGATIONTYPE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INVESTIGATIONTYPE'
-                type: array
-          description: Success - returns INVESTIGATIONTYPE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/INVESTIGATIONTYPE'
+                - items:
+                    $ref: '#/components/schemas/INVESTIGATIONTYPE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6646,7 +6646,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get InvestigationTypes
+      summary: Create new InvestigationTypes
       tags:
       - InvestigationTypes
   /investigationtypes/{id_}:
@@ -6673,6 +6673,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete InvestigationTypes by id
+      tags:
+      - InvestigationTypes
+    get:
+      description: Retrieves a list of INVESTIGATIONTYPE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INVESTIGATIONTYPE'
+          description: Success - the matching INVESTIGATIONTYPE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INVESTIGATIONTYPE matching the given ID
       tags:
       - InvestigationTypes
     patch:
@@ -6709,34 +6737,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update InvestigationTypes by id
-      tags:
-      - InvestigationTypes
-    get:
-      description: Retrieves a list of INVESTIGATIONTYPE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INVESTIGATIONTYPE'
-          description: Success - the matching INVESTIGATIONTYPE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INVESTIGATIONTYPE matching the given ID
       tags:
       - InvestigationTypes
   /investigationtypes/count:
@@ -6797,31 +6797,24 @@ paths:
       tags:
       - InvestigationTypes
   /investigationusers:
-    post:
-      description: Creates new INVESTIGATIONUSER object(s) with details provided in
-        the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INVESTIGATIONUSER'
-              - items:
-                  $ref: '#/components/schemas/INVESTIGATIONUSER'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INVESTIGATIONUSER objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INVESTIGATIONUSER'
-                - items:
-                    $ref: '#/components/schemas/INVESTIGATIONUSER'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INVESTIGATIONUSER'
+                type: array
+          description: Success - returns INVESTIGATIONUSER that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6831,7 +6824,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new InvestigationUsers
+      summary: Get InvestigationUsers
       tags:
       - InvestigationUsers
     patch:
@@ -6871,24 +6864,31 @@ paths:
       summary: Update InvestigationUsers
       tags:
       - InvestigationUsers
-    get:
-      description: Retrieves a list of INVESTIGATIONUSER objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INVESTIGATIONUSER object(s) with details provided in
+        the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INVESTIGATIONUSER'
+              - items:
+                  $ref: '#/components/schemas/INVESTIGATIONUSER'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INVESTIGATIONUSER'
-                type: array
-          description: Success - returns INVESTIGATIONUSER that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/INVESTIGATIONUSER'
+                - items:
+                    $ref: '#/components/schemas/INVESTIGATIONUSER'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -6898,7 +6898,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get InvestigationUsers
+      summary: Create new InvestigationUsers
       tags:
       - InvestigationUsers
   /investigationusers/{id_}:
@@ -6925,6 +6925,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete InvestigationUsers by id
+      tags:
+      - InvestigationUsers
+    get:
+      description: Retrieves a list of INVESTIGATIONUSER objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INVESTIGATIONUSER'
+          description: Success - the matching INVESTIGATIONUSER
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INVESTIGATIONUSER matching the given ID
       tags:
       - InvestigationUsers
     patch:
@@ -6961,34 +6989,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update InvestigationUsers by id
-      tags:
-      - InvestigationUsers
-    get:
-      description: Retrieves a list of INVESTIGATIONUSER objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INVESTIGATIONUSER'
-          description: Success - the matching INVESTIGATIONUSER
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INVESTIGATIONUSER matching the given ID
       tags:
       - InvestigationUsers
   /investigationusers/count:
@@ -7049,31 +7049,24 @@ paths:
       tags:
       - InvestigationUsers
   /investigations:
-    post:
-      description: Creates new INVESTIGATION object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/INVESTIGATION'
-              - items:
-                  $ref: '#/components/schemas/INVESTIGATION'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of INVESTIGATION objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/INVESTIGATION'
-                - items:
-                    $ref: '#/components/schemas/INVESTIGATION'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/INVESTIGATION'
+                type: array
+          description: Success - returns INVESTIGATION that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7083,7 +7076,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Investigations
+      summary: Get Investigations
       tags:
       - Investigations
     patch:
@@ -7123,24 +7116,31 @@ paths:
       summary: Update Investigations
       tags:
       - Investigations
-    get:
-      description: Retrieves a list of INVESTIGATION objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new INVESTIGATION object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/INVESTIGATION'
+              - items:
+                  $ref: '#/components/schemas/INVESTIGATION'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/INVESTIGATION'
-                type: array
-          description: Success - returns INVESTIGATION that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/INVESTIGATION'
+                - items:
+                    $ref: '#/components/schemas/INVESTIGATION'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7150,7 +7150,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Investigations
+      summary: Create new Investigations
       tags:
       - Investigations
   /investigations/{id_}:
@@ -7177,6 +7177,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Investigations by id
+      tags:
+      - Investigations
+    get:
+      description: Retrieves a list of INVESTIGATION objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/INVESTIGATION'
+          description: Success - the matching INVESTIGATION
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the INVESTIGATION matching the given ID
       tags:
       - Investigations
     patch:
@@ -7213,34 +7241,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Investigations by id
-      tags:
-      - Investigations
-    get:
-      description: Retrieves a list of INVESTIGATION objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/INVESTIGATION'
-          description: Success - the matching INVESTIGATION
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the INVESTIGATION matching the given ID
       tags:
       - Investigations
   /investigations/count:
@@ -7300,31 +7300,24 @@ paths:
       tags:
       - Investigations
   /jobs:
-    post:
-      description: Creates new JOB object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/JOB'
-              - items:
-                  $ref: '#/components/schemas/JOB'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of JOB objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/JOB'
-                - items:
-                    $ref: '#/components/schemas/JOB'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/JOB'
+                type: array
+          description: Success - returns JOB that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7334,7 +7327,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Jobs
+      summary: Get Jobs
       tags:
       - Jobs
     patch:
@@ -7373,24 +7366,31 @@ paths:
       summary: Update Jobs
       tags:
       - Jobs
-    get:
-      description: Retrieves a list of JOB objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new JOB object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/JOB'
+              - items:
+                  $ref: '#/components/schemas/JOB'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/JOB'
-                type: array
-          description: Success - returns JOB that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/JOB'
+                - items:
+                    $ref: '#/components/schemas/JOB'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7400,7 +7400,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Jobs
+      summary: Create new Jobs
       tags:
       - Jobs
   /jobs/{id_}:
@@ -7427,6 +7427,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Jobs by id
+      tags:
+      - Jobs
+    get:
+      description: Retrieves a list of JOB objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JOB'
+          description: Success - the matching JOB
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the JOB matching the given ID
       tags:
       - Jobs
     patch:
@@ -7463,34 +7491,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Jobs by id
-      tags:
-      - Jobs
-    get:
-      description: Retrieves a list of JOB objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JOB'
-          description: Success - the matching JOB
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the JOB matching the given ID
       tags:
       - Jobs
   /jobs/count:
@@ -7550,31 +7550,24 @@ paths:
       tags:
       - Jobs
   /keywords:
-    post:
-      description: Creates new KEYWORD object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/KEYWORD'
-              - items:
-                  $ref: '#/components/schemas/KEYWORD'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of KEYWORD objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/KEYWORD'
-                - items:
-                    $ref: '#/components/schemas/KEYWORD'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/KEYWORD'
+                type: array
+          description: Success - returns KEYWORD that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7584,7 +7577,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Keywords
+      summary: Get Keywords
       tags:
       - Keywords
     patch:
@@ -7624,24 +7617,31 @@ paths:
       summary: Update Keywords
       tags:
       - Keywords
-    get:
-      description: Retrieves a list of KEYWORD objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new KEYWORD object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/KEYWORD'
+              - items:
+                  $ref: '#/components/schemas/KEYWORD'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/KEYWORD'
-                type: array
-          description: Success - returns KEYWORD that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/KEYWORD'
+                - items:
+                    $ref: '#/components/schemas/KEYWORD'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7651,7 +7651,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Keywords
+      summary: Create new Keywords
       tags:
       - Keywords
   /keywords/{id_}:
@@ -7678,6 +7678,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Keywords by id
+      tags:
+      - Keywords
+    get:
+      description: Retrieves a list of KEYWORD objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KEYWORD'
+          description: Success - the matching KEYWORD
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the KEYWORD matching the given ID
       tags:
       - Keywords
     patch:
@@ -7714,34 +7742,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Keywords by id
-      tags:
-      - Keywords
-    get:
-      description: Retrieves a list of KEYWORD objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KEYWORD'
-          description: Success - the matching KEYWORD
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the KEYWORD matching the given ID
       tags:
       - Keywords
   /keywords/count:
@@ -7801,31 +7801,24 @@ paths:
       tags:
       - Keywords
   /parametertypes:
-    post:
-      description: Creates new PARAMETERTYPE object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/PARAMETERTYPE'
-              - items:
-                  $ref: '#/components/schemas/PARAMETERTYPE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of PARAMETERTYPE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/PARAMETERTYPE'
-                - items:
-                    $ref: '#/components/schemas/PARAMETERTYPE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/PARAMETERTYPE'
+                type: array
+          description: Success - returns PARAMETERTYPE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7835,7 +7828,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new ParameterTypes
+      summary: Get ParameterTypes
       tags:
       - ParameterTypes
     patch:
@@ -7875,24 +7868,31 @@ paths:
       summary: Update ParameterTypes
       tags:
       - ParameterTypes
-    get:
-      description: Retrieves a list of PARAMETERTYPE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new PARAMETERTYPE object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/PARAMETERTYPE'
+              - items:
+                  $ref: '#/components/schemas/PARAMETERTYPE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/PARAMETERTYPE'
-                type: array
-          description: Success - returns PARAMETERTYPE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/PARAMETERTYPE'
+                - items:
+                    $ref: '#/components/schemas/PARAMETERTYPE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -7902,7 +7902,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get ParameterTypes
+      summary: Create new ParameterTypes
       tags:
       - ParameterTypes
   /parametertypes/{id_}:
@@ -7929,6 +7929,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete ParameterTypes by id
+      tags:
+      - ParameterTypes
+    get:
+      description: Retrieves a list of PARAMETERTYPE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PARAMETERTYPE'
+          description: Success - the matching PARAMETERTYPE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the PARAMETERTYPE matching the given ID
       tags:
       - ParameterTypes
     patch:
@@ -7965,34 +7993,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update ParameterTypes by id
-      tags:
-      - ParameterTypes
-    get:
-      description: Retrieves a list of PARAMETERTYPE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PARAMETERTYPE'
-          description: Success - the matching PARAMETERTYPE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the PARAMETERTYPE matching the given ID
       tags:
       - ParameterTypes
   /parametertypes/count:
@@ -8052,31 +8052,24 @@ paths:
       tags:
       - ParameterTypes
   /permissiblestringvalues:
-    post:
-      description: Creates new PERMISSIBLESTRINGVALUE object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
-              - items:
-                  $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of PERMISSIBLESTRINGVALUE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
-                - items:
-                    $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
+                type: array
+          description: Success - returns PERMISSIBLESTRINGVALUE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8086,7 +8079,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new PermissibleStringValues
+      summary: Get PermissibleStringValues
       tags:
       - PermissibleStringValues
     patch:
@@ -8126,24 +8119,31 @@ paths:
       summary: Update PermissibleStringValues
       tags:
       - PermissibleStringValues
-    get:
-      description: Retrieves a list of PERMISSIBLESTRINGVALUE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new PERMISSIBLESTRINGVALUE object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
+              - items:
+                  $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
-                type: array
-          description: Success - returns PERMISSIBLESTRINGVALUE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
+                - items:
+                    $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8153,7 +8153,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get PermissibleStringValues
+      summary: Create new PermissibleStringValues
       tags:
       - PermissibleStringValues
   /permissiblestringvalues/{id_}:
@@ -8180,6 +8180,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete PermissibleStringValues by id
+      tags:
+      - PermissibleStringValues
+    get:
+      description: Retrieves a list of PERMISSIBLESTRINGVALUE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
+          description: Success - the matching PERMISSIBLESTRINGVALUE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the PERMISSIBLESTRINGVALUE matching the given ID
       tags:
       - PermissibleStringValues
     patch:
@@ -8216,34 +8244,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update PermissibleStringValues by id
-      tags:
-      - PermissibleStringValues
-    get:
-      description: Retrieves a list of PERMISSIBLESTRINGVALUE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PERMISSIBLESTRINGVALUE'
-          description: Success - the matching PERMISSIBLESTRINGVALUE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the PERMISSIBLESTRINGVALUE matching the given ID
       tags:
       - PermissibleStringValues
   /permissiblestringvalues/count:
@@ -8305,31 +8305,24 @@ paths:
       tags:
       - PermissibleStringValues
   /publicsteps:
-    post:
-      description: Creates new PUBLICSTEP object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/PUBLICSTEP'
-              - items:
-                  $ref: '#/components/schemas/PUBLICSTEP'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of PUBLICSTEP objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/PUBLICSTEP'
-                - items:
-                    $ref: '#/components/schemas/PUBLICSTEP'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/PUBLICSTEP'
+                type: array
+          description: Success - returns PUBLICSTEP that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8339,7 +8332,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new PublicSteps
+      summary: Get PublicSteps
       tags:
       - PublicSteps
     patch:
@@ -8379,24 +8372,31 @@ paths:
       summary: Update PublicSteps
       tags:
       - PublicSteps
-    get:
-      description: Retrieves a list of PUBLICSTEP objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new PUBLICSTEP object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/PUBLICSTEP'
+              - items:
+                  $ref: '#/components/schemas/PUBLICSTEP'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/PUBLICSTEP'
-                type: array
-          description: Success - returns PUBLICSTEP that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/PUBLICSTEP'
+                - items:
+                    $ref: '#/components/schemas/PUBLICSTEP'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8406,7 +8406,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get PublicSteps
+      summary: Create new PublicSteps
       tags:
       - PublicSteps
   /publicsteps/{id_}:
@@ -8433,6 +8433,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete PublicSteps by id
+      tags:
+      - PublicSteps
+    get:
+      description: Retrieves a list of PUBLICSTEP objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PUBLICSTEP'
+          description: Success - the matching PUBLICSTEP
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the PUBLICSTEP matching the given ID
       tags:
       - PublicSteps
     patch:
@@ -8469,34 +8497,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update PublicSteps by id
-      tags:
-      - PublicSteps
-    get:
-      description: Retrieves a list of PUBLICSTEP objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PUBLICSTEP'
-          description: Success - the matching PUBLICSTEP
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the PUBLICSTEP matching the given ID
       tags:
       - PublicSteps
   /publicsteps/count:
@@ -8556,31 +8556,24 @@ paths:
       tags:
       - PublicSteps
   /publications:
-    post:
-      description: Creates new PUBLICATION object(s) with details provided in the
-        request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/PUBLICATION'
-              - items:
-                  $ref: '#/components/schemas/PUBLICATION'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of PUBLICATION objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/PUBLICATION'
-                - items:
-                    $ref: '#/components/schemas/PUBLICATION'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/PUBLICATION'
+                type: array
+          description: Success - returns PUBLICATION that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8590,7 +8583,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Publications
+      summary: Get Publications
       tags:
       - Publications
     patch:
@@ -8630,24 +8623,31 @@ paths:
       summary: Update Publications
       tags:
       - Publications
-    get:
-      description: Retrieves a list of PUBLICATION objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new PUBLICATION object(s) with details provided in the
+        request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/PUBLICATION'
+              - items:
+                  $ref: '#/components/schemas/PUBLICATION'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/PUBLICATION'
-                type: array
-          description: Success - returns PUBLICATION that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/PUBLICATION'
+                - items:
+                    $ref: '#/components/schemas/PUBLICATION'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8657,7 +8657,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Publications
+      summary: Create new Publications
       tags:
       - Publications
   /publications/{id_}:
@@ -8684,6 +8684,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Publications by id
+      tags:
+      - Publications
+    get:
+      description: Retrieves a list of PUBLICATION objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PUBLICATION'
+          description: Success - the matching PUBLICATION
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the PUBLICATION matching the given ID
       tags:
       - Publications
     patch:
@@ -8720,34 +8748,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Publications by id
-      tags:
-      - Publications
-    get:
-      description: Retrieves a list of PUBLICATION objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PUBLICATION'
-          description: Success - the matching PUBLICATION
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the PUBLICATION matching the given ID
       tags:
       - Publications
   /publications/count:
@@ -8807,31 +8807,24 @@ paths:
       tags:
       - Publications
   /relateddatafiles:
-    post:
-      description: Creates new RELATEDDATAFILE object(s) with details provided in
-        the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/RELATEDDATAFILE'
-              - items:
-                  $ref: '#/components/schemas/RELATEDDATAFILE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of RELATEDDATAFILE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/RELATEDDATAFILE'
-                - items:
-                    $ref: '#/components/schemas/RELATEDDATAFILE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/RELATEDDATAFILE'
+                type: array
+          description: Success - returns RELATEDDATAFILE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8841,7 +8834,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new RelatedDatafiles
+      summary: Get RelatedDatafiles
       tags:
       - RelatedDatafiles
     patch:
@@ -8881,24 +8874,31 @@ paths:
       summary: Update RelatedDatafiles
       tags:
       - RelatedDatafiles
-    get:
-      description: Retrieves a list of RELATEDDATAFILE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new RELATEDDATAFILE object(s) with details provided in
+        the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/RELATEDDATAFILE'
+              - items:
+                  $ref: '#/components/schemas/RELATEDDATAFILE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/RELATEDDATAFILE'
-                type: array
-          description: Success - returns RELATEDDATAFILE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/RELATEDDATAFILE'
+                - items:
+                    $ref: '#/components/schemas/RELATEDDATAFILE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -8908,7 +8908,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get RelatedDatafiles
+      summary: Create new RelatedDatafiles
       tags:
       - RelatedDatafiles
   /relateddatafiles/{id_}:
@@ -8935,6 +8935,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete RelatedDatafiles by id
+      tags:
+      - RelatedDatafiles
+    get:
+      description: Retrieves a list of RELATEDDATAFILE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RELATEDDATAFILE'
+          description: Success - the matching RELATEDDATAFILE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the RELATEDDATAFILE matching the given ID
       tags:
       - RelatedDatafiles
     patch:
@@ -8971,34 +8999,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update RelatedDatafiles by id
-      tags:
-      - RelatedDatafiles
-    get:
-      description: Retrieves a list of RELATEDDATAFILE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RELATEDDATAFILE'
-          description: Success - the matching RELATEDDATAFILE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the RELATEDDATAFILE matching the given ID
       tags:
       - RelatedDatafiles
   /relateddatafiles/count:
@@ -9059,31 +9059,24 @@ paths:
       tags:
       - RelatedDatafiles
   /rules:
-    post:
-      description: Creates new RULE object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/RULE'
-              - items:
-                  $ref: '#/components/schemas/RULE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of RULE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/RULE'
-                - items:
-                    $ref: '#/components/schemas/RULE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/RULE'
+                type: array
+          description: Success - returns RULE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9093,7 +9086,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Rules
+      summary: Get Rules
       tags:
       - Rules
     patch:
@@ -9132,24 +9125,31 @@ paths:
       summary: Update Rules
       tags:
       - Rules
-    get:
-      description: Retrieves a list of RULE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new RULE object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/RULE'
+              - items:
+                  $ref: '#/components/schemas/RULE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/RULE'
-                type: array
-          description: Success - returns RULE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/RULE'
+                - items:
+                    $ref: '#/components/schemas/RULE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9159,7 +9159,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Rules
+      summary: Create new Rules
       tags:
       - Rules
   /rules/{id_}:
@@ -9186,6 +9186,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Rules by id
+      tags:
+      - Rules
+    get:
+      description: Retrieves a list of RULE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RULE'
+          description: Success - the matching RULE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the RULE matching the given ID
       tags:
       - Rules
     patch:
@@ -9222,34 +9250,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Rules by id
-      tags:
-      - Rules
-    get:
-      description: Retrieves a list of RULE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RULE'
-          description: Success - the matching RULE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the RULE matching the given ID
       tags:
       - Rules
   /rules/count:
@@ -9309,31 +9309,24 @@ paths:
       tags:
       - Rules
   /sampleparameters:
-    post:
-      description: Creates new SAMPLEPARAMETER object(s) with details provided in
-        the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/SAMPLEPARAMETER'
-              - items:
-                  $ref: '#/components/schemas/SAMPLEPARAMETER'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of SAMPLEPARAMETER objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/SAMPLEPARAMETER'
-                - items:
-                    $ref: '#/components/schemas/SAMPLEPARAMETER'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/SAMPLEPARAMETER'
+                type: array
+          description: Success - returns SAMPLEPARAMETER that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9343,7 +9336,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new SampleParameters
+      summary: Get SampleParameters
       tags:
       - SampleParameters
     patch:
@@ -9383,24 +9376,31 @@ paths:
       summary: Update SampleParameters
       tags:
       - SampleParameters
-    get:
-      description: Retrieves a list of SAMPLEPARAMETER objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new SAMPLEPARAMETER object(s) with details provided in
+        the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/SAMPLEPARAMETER'
+              - items:
+                  $ref: '#/components/schemas/SAMPLEPARAMETER'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/SAMPLEPARAMETER'
-                type: array
-          description: Success - returns SAMPLEPARAMETER that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/SAMPLEPARAMETER'
+                - items:
+                    $ref: '#/components/schemas/SAMPLEPARAMETER'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9410,7 +9410,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get SampleParameters
+      summary: Create new SampleParameters
       tags:
       - SampleParameters
   /sampleparameters/{id_}:
@@ -9437,6 +9437,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete SampleParameters by id
+      tags:
+      - SampleParameters
+    get:
+      description: Retrieves a list of SAMPLEPARAMETER objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SAMPLEPARAMETER'
+          description: Success - the matching SAMPLEPARAMETER
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the SAMPLEPARAMETER matching the given ID
       tags:
       - SampleParameters
     patch:
@@ -9473,34 +9501,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update SampleParameters by id
-      tags:
-      - SampleParameters
-    get:
-      description: Retrieves a list of SAMPLEPARAMETER objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SAMPLEPARAMETER'
-          description: Success - the matching SAMPLEPARAMETER
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the SAMPLEPARAMETER matching the given ID
       tags:
       - SampleParameters
   /sampleparameters/count:
@@ -9561,31 +9561,24 @@ paths:
       tags:
       - SampleParameters
   /sampletypes:
-    post:
-      description: Creates new SAMPLETYPE object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/SAMPLETYPE'
-              - items:
-                  $ref: '#/components/schemas/SAMPLETYPE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of SAMPLETYPE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/SAMPLETYPE'
-                - items:
-                    $ref: '#/components/schemas/SAMPLETYPE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/SAMPLETYPE'
+                type: array
+          description: Success - returns SAMPLETYPE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9595,7 +9588,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new SampleTypes
+      summary: Get SampleTypes
       tags:
       - SampleTypes
     patch:
@@ -9635,24 +9628,31 @@ paths:
       summary: Update SampleTypes
       tags:
       - SampleTypes
-    get:
-      description: Retrieves a list of SAMPLETYPE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new SAMPLETYPE object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/SAMPLETYPE'
+              - items:
+                  $ref: '#/components/schemas/SAMPLETYPE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/SAMPLETYPE'
-                type: array
-          description: Success - returns SAMPLETYPE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/SAMPLETYPE'
+                - items:
+                    $ref: '#/components/schemas/SAMPLETYPE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9662,7 +9662,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get SampleTypes
+      summary: Create new SampleTypes
       tags:
       - SampleTypes
   /sampletypes/{id_}:
@@ -9689,6 +9689,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete SampleTypes by id
+      tags:
+      - SampleTypes
+    get:
+      description: Retrieves a list of SAMPLETYPE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SAMPLETYPE'
+          description: Success - the matching SAMPLETYPE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the SAMPLETYPE matching the given ID
       tags:
       - SampleTypes
     patch:
@@ -9725,34 +9753,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update SampleTypes by id
-      tags:
-      - SampleTypes
-    get:
-      description: Retrieves a list of SAMPLETYPE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SAMPLETYPE'
-          description: Success - the matching SAMPLETYPE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the SAMPLETYPE matching the given ID
       tags:
       - SampleTypes
   /sampletypes/count:
@@ -9812,31 +9812,24 @@ paths:
       tags:
       - SampleTypes
   /samples:
-    post:
-      description: Creates new SAMPLE object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/SAMPLE'
-              - items:
-                  $ref: '#/components/schemas/SAMPLE'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of SAMPLE objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/SAMPLE'
-                - items:
-                    $ref: '#/components/schemas/SAMPLE'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/SAMPLE'
+                type: array
+          description: Success - returns SAMPLE that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9846,7 +9839,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Samples
+      summary: Get Samples
       tags:
       - Samples
     patch:
@@ -9885,24 +9878,31 @@ paths:
       summary: Update Samples
       tags:
       - Samples
-    get:
-      description: Retrieves a list of SAMPLE objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new SAMPLE object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/SAMPLE'
+              - items:
+                  $ref: '#/components/schemas/SAMPLE'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/SAMPLE'
-                type: array
-          description: Success - returns SAMPLE that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/SAMPLE'
+                - items:
+                    $ref: '#/components/schemas/SAMPLE'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -9912,7 +9912,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Samples
+      summary: Create new Samples
       tags:
       - Samples
   /samples/{id_}:
@@ -9939,6 +9939,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Samples by id
+      tags:
+      - Samples
+    get:
+      description: Retrieves a list of SAMPLE objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SAMPLE'
+          description: Success - the matching SAMPLE
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the SAMPLE matching the given ID
       tags:
       - Samples
     patch:
@@ -9975,34 +10003,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Samples by id
-      tags:
-      - Samples
-    get:
-      description: Retrieves a list of SAMPLE objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SAMPLE'
-          description: Success - the matching SAMPLE
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the SAMPLE matching the given ID
       tags:
       - Samples
   /samples/count:
@@ -10062,31 +10062,24 @@ paths:
       tags:
       - Samples
   /shifts:
-    post:
-      description: Creates new SHIFT object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/SHIFT'
-              - items:
-                  $ref: '#/components/schemas/SHIFT'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of SHIFT objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/SHIFT'
-                - items:
-                    $ref: '#/components/schemas/SHIFT'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/SHIFT'
+                type: array
+          description: Success - returns SHIFT that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10096,7 +10089,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Shifts
+      summary: Get Shifts
       tags:
       - Shifts
     patch:
@@ -10135,24 +10128,31 @@ paths:
       summary: Update Shifts
       tags:
       - Shifts
-    get:
-      description: Retrieves a list of SHIFT objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new SHIFT object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/SHIFT'
+              - items:
+                  $ref: '#/components/schemas/SHIFT'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/SHIFT'
-                type: array
-          description: Success - returns SHIFT that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/SHIFT'
+                - items:
+                    $ref: '#/components/schemas/SHIFT'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10162,7 +10162,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Shifts
+      summary: Create new Shifts
       tags:
       - Shifts
   /shifts/{id_}:
@@ -10189,6 +10189,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Shifts by id
+      tags:
+      - Shifts
+    get:
+      description: Retrieves a list of SHIFT objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SHIFT'
+          description: Success - the matching SHIFT
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the SHIFT matching the given ID
       tags:
       - Shifts
     patch:
@@ -10225,34 +10253,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Shifts by id
-      tags:
-      - Shifts
-    get:
-      description: Retrieves a list of SHIFT objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SHIFT'
-          description: Success - the matching SHIFT
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the SHIFT matching the given ID
       tags:
       - Shifts
   /shifts/count:
@@ -10312,31 +10312,24 @@ paths:
       tags:
       - Shifts
   /studies:
-    post:
-      description: Creates new STUDY object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/STUDY'
-              - items:
-                  $ref: '#/components/schemas/STUDY'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of STUDY objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/STUDY'
-                - items:
-                    $ref: '#/components/schemas/STUDY'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/STUDY'
+                type: array
+          description: Success - returns STUDY that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10346,7 +10339,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Studies
+      summary: Get Studies
       tags:
       - Studies
     patch:
@@ -10385,24 +10378,31 @@ paths:
       summary: Update Studies
       tags:
       - Studies
-    get:
-      description: Retrieves a list of STUDY objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new STUDY object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/STUDY'
+              - items:
+                  $ref: '#/components/schemas/STUDY'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/STUDY'
-                type: array
-          description: Success - returns STUDY that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/STUDY'
+                - items:
+                    $ref: '#/components/schemas/STUDY'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10412,7 +10412,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Studies
+      summary: Create new Studies
       tags:
       - Studies
   /studies/{id_}:
@@ -10439,6 +10439,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Studies by id
+      tags:
+      - Studies
+    get:
+      description: Retrieves a list of STUDY objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/STUDY'
+          description: Success - the matching STUDY
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the STUDY matching the given ID
       tags:
       - Studies
     patch:
@@ -10475,34 +10503,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Studies by id
-      tags:
-      - Studies
-    get:
-      description: Retrieves a list of STUDY objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/STUDY'
-          description: Success - the matching STUDY
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the STUDY matching the given ID
       tags:
       - Studies
   /studies/count:
@@ -10562,31 +10562,24 @@ paths:
       tags:
       - Studies
   /studyinvestigations:
-    post:
-      description: Creates new STUDYINVESTIGATION object(s) with details provided
-        in the request body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/STUDYINVESTIGATION'
-              - items:
-                  $ref: '#/components/schemas/STUDYINVESTIGATION'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of STUDYINVESTIGATION objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/STUDYINVESTIGATION'
-                - items:
-                    $ref: '#/components/schemas/STUDYINVESTIGATION'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/STUDYINVESTIGATION'
+                type: array
+          description: Success - returns STUDYINVESTIGATION that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10596,7 +10589,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new StudyInvestigations
+      summary: Get StudyInvestigations
       tags:
       - StudyInvestigations
     patch:
@@ -10636,24 +10629,31 @@ paths:
       summary: Update StudyInvestigations
       tags:
       - StudyInvestigations
-    get:
-      description: Retrieves a list of STUDYINVESTIGATION objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new STUDYINVESTIGATION object(s) with details provided
+        in the request body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/STUDYINVESTIGATION'
+              - items:
+                  $ref: '#/components/schemas/STUDYINVESTIGATION'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/STUDYINVESTIGATION'
-                type: array
-          description: Success - returns STUDYINVESTIGATION that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/STUDYINVESTIGATION'
+                - items:
+                    $ref: '#/components/schemas/STUDYINVESTIGATION'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10663,7 +10663,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get StudyInvestigations
+      summary: Create new StudyInvestigations
       tags:
       - StudyInvestigations
   /studyinvestigations/{id_}:
@@ -10690,6 +10690,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete StudyInvestigations by id
+      tags:
+      - StudyInvestigations
+    get:
+      description: Retrieves a list of STUDYINVESTIGATION objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/STUDYINVESTIGATION'
+          description: Success - the matching STUDYINVESTIGATION
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the STUDYINVESTIGATION matching the given ID
       tags:
       - StudyInvestigations
     patch:
@@ -10726,34 +10754,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update StudyInvestigations by id
-      tags:
-      - StudyInvestigations
-    get:
-      description: Retrieves a list of STUDYINVESTIGATION objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/STUDYINVESTIGATION'
-          description: Success - the matching STUDYINVESTIGATION
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the STUDYINVESTIGATION matching the given ID
       tags:
       - StudyInvestigations
   /studyinvestigations/count:
@@ -10814,31 +10814,24 @@ paths:
       tags:
       - StudyInvestigations
   /usergroups:
-    post:
-      description: Creates new USERGROUP object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/USERGROUP'
-              - items:
-                  $ref: '#/components/schemas/USERGROUP'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of USERGROUP objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/USERGROUP'
-                - items:
-                    $ref: '#/components/schemas/USERGROUP'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/USERGROUP'
+                type: array
+          description: Success - returns USERGROUP that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10848,7 +10841,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new UserGroups
+      summary: Get UserGroups
       tags:
       - UserGroups
     patch:
@@ -10888,24 +10881,31 @@ paths:
       summary: Update UserGroups
       tags:
       - UserGroups
-    get:
-      description: Retrieves a list of USERGROUP objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new USERGROUP object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/USERGROUP'
+              - items:
+                  $ref: '#/components/schemas/USERGROUP'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/USERGROUP'
-                type: array
-          description: Success - returns USERGROUP that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/USERGROUP'
+                - items:
+                    $ref: '#/components/schemas/USERGROUP'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -10915,7 +10915,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get UserGroups
+      summary: Create new UserGroups
       tags:
       - UserGroups
   /usergroups/{id_}:
@@ -10942,6 +10942,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete UserGroups by id
+      tags:
+      - UserGroups
+    get:
+      description: Retrieves a list of USERGROUP objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/USERGROUP'
+          description: Success - the matching USERGROUP
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the USERGROUP matching the given ID
       tags:
       - UserGroups
     patch:
@@ -10978,34 +11006,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update UserGroups by id
-      tags:
-      - UserGroups
-    get:
-      description: Retrieves a list of USERGROUP objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/USERGROUP'
-          description: Success - the matching USERGROUP
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the USERGROUP matching the given ID
       tags:
       - UserGroups
   /usergroups/count:
@@ -11065,31 +11065,24 @@ paths:
       tags:
       - UserGroups
   /users:
-    post:
-      description: Creates new USER object(s) with details provided in the request
-        body
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - $ref: '#/components/schemas/USER'
-              - items:
-                  $ref: '#/components/schemas/USER'
-                type: array
-        description: The values to use to create the new object(s) with
-        required: true
+    get:
+      description: Retrieves a list of USER objects
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      - $ref: '#/components/parameters/ORDER_FILTER'
+      - $ref: '#/components/parameters/LIMIT_FILTER'
+      - $ref: '#/components/parameters/SKIP_FILTER'
+      - $ref: '#/components/parameters/DISTINCT_FILTER'
+      - $ref: '#/components/parameters/INCLUDE_FILTER'
       responses:
         '200':
           content:
             application/json:
               schema:
-                oneOf:
-                - $ref: '#/components/schemas/USER'
-                - items:
-                    $ref: '#/components/schemas/USER'
-                  type: array
-          description: Success - returns the created object
+                items:
+                  $ref: '#/components/schemas/USER'
+                type: array
+          description: Success - returns USER that satisfy the filters
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -11099,7 +11092,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Create new Users
+      summary: Get Users
       tags:
       - Users
     patch:
@@ -11138,24 +11131,31 @@ paths:
       summary: Update Users
       tags:
       - Users
-    get:
-      description: Retrieves a list of USER objects
-      parameters:
-      - $ref: '#/components/parameters/WHERE_FILTER'
-      - $ref: '#/components/parameters/ORDER_FILTER'
-      - $ref: '#/components/parameters/LIMIT_FILTER'
-      - $ref: '#/components/parameters/SKIP_FILTER'
-      - $ref: '#/components/parameters/DISTINCT_FILTER'
-      - $ref: '#/components/parameters/INCLUDE_FILTER'
+    post:
+      description: Creates new USER object(s) with details provided in the request
+        body
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/USER'
+              - items:
+                  $ref: '#/components/schemas/USER'
+                type: array
+        description: The values to use to create the new object(s) with
+        required: true
       responses:
         '200':
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/USER'
-                type: array
-          description: Success - returns USER that satisfy the filters
+                oneOf:
+                - $ref: '#/components/schemas/USER'
+                - items:
+                    $ref: '#/components/schemas/USER'
+                  type: array
+          description: Success - returns the created object
         '400':
           description: Bad request - Something was wrong with the request
         '401':
@@ -11165,7 +11165,7 @@ paths:
           description: Forbidden - The session ID provided is invalid
         '404':
           description: No such record - Unable to find a record in the database
-      summary: Get Users
+      summary: Create new Users
       tags:
       - Users
   /users/{id_}:
@@ -11192,6 +11192,34 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Delete Users by id
+      tags:
+      - Users
+    get:
+      description: Retrieves a list of USER objects
+      parameters:
+      - description: The id of the entity to retrieve
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/USER'
+          description: Success - the matching USER
+        '400':
+          description: Bad request - Something was wrong with the request
+        '401':
+          description: Unauthorized - No session ID was found in the HTTP Authorization
+            header
+        '403':
+          description: Forbidden - The session ID provided is invalid
+        '404':
+          description: No such record - Unable to find a record in the database
+      summary: Find the USER matching the given ID
       tags:
       - Users
     patch:
@@ -11228,34 +11256,6 @@ paths:
         '404':
           description: No such record - Unable to find a record in the database
       summary: Update Users by id
-      tags:
-      - Users
-    get:
-      description: Retrieves a list of USER objects
-      parameters:
-      - description: The id of the entity to retrieve
-        in: path
-        name: id
-        required: true
-        schema:
-          type: integer
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/USER'
-          description: Success - the matching USER
-        '400':
-          description: Bad request - Something was wrong with the request
-        '401':
-          description: Unauthorized - No session ID was found in the HTTP Authorization
-            header
-        '403':
-          description: Forbidden - The session ID provided is invalid
-        '404':
-          description: No such record - Unable to find a record in the database
-      summary: Find the USER matching the given ID
       tags:
       - Users
   /users/count:
@@ -11332,23 +11332,34 @@ paths:
       summary: Delete session
       tags:
       - Sessions
-    put:
-      description: Refreshes a users session
+    get:
+      description: Gives details of a user's session
       responses:
         '200':
           content:
             application/json:
               schema:
-                description: Session ID
-                example: xxxxxx-yyyyyyy-zzzzzz
-                type: string
-          description: Success - the user's session ID that has been refreshed
+                properties:
+                  EXPIREDATETIME:
+                    description: When this session expires
+                    example: '2017-07-21T17:32:28Z'
+                    format: datetime
+                    type: string
+                  ID:
+                    description: The session ID
+                    example: xxxxxx-yyyyyyy-zzzzzz
+                    type: string
+                  USERNAME:
+                    description: Username associated with this session
+                    type: string
+                type: object
+          description: Success - a user's session details
         '401':
           description: Unauthorized - No session ID was found in the HTTP Authorization
             header
         '403':
           description: Forbidden - The session ID provided is invalid
-      summary: Refresh session
+      summary: Get session details
       tags:
       - Sessions
     post:
@@ -11388,34 +11399,23 @@ paths:
       summary: Login
       tags:
       - Sessions
-    get:
-      description: Gives details of a user's session
+    put:
+      description: Refreshes a users session
       responses:
         '200':
           content:
             application/json:
               schema:
-                properties:
-                  EXPIREDATETIME:
-                    description: When this session expires
-                    example: '2017-07-21T17:32:28Z'
-                    format: datetime
-                    type: string
-                  ID:
-                    description: The session ID
-                    example: xxxxxx-yyyyyyy-zzzzzz
-                    type: string
-                  USERNAME:
-                    description: Username associated with this session
-                    type: string
-                type: object
-          description: Success - a user's session details
+                description: Session ID
+                example: xxxxxx-yyyyyyy-zzzzzz
+                type: string
+          description: Success - the user's session ID that has been refreshed
         '401':
           description: Unauthorized - No session ID was found in the HTTP Authorization
             header
         '403':
           description: Forbidden - The session ID provided is invalid
-      summary: Get session details
+      summary: Refresh session
       tags:
       - Sessions
   /instruments/{id_}/facilitycycles:


### PR DESCRIPTION
This PR will close #164.

This is a very simple PR to improve the logging throughout the Python ICAT backend. I've been better at this more recently, but some of the earlier development didn't have much logging in it. It's not overly detailed to prevent the log files from being bloated, but it gives information about what the user is doing within the API.