### PR TITLE
Update Swagger Generation Section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ ICAT API to interface with the Data Gateway
       - [Main](#main)
       - [Endpoints](#endpoints)
       - [Mapped classes](#mapped-classes)
+      - [Database Generator](#database-generator)
+      - [Class Diagrams](#class-diagrams-for-this-module)
       - [Querying and filtering](#querying-and-filtering)
       - [Swagger Generation](#generating-the-swagger-spec-openapiyaml)
       - [Authentication](#authentication)
@@ -25,8 +27,12 @@ The required python libraries:
    - [SQLAlchemy](https://www.sqlalchemy.org/)    
    - [flask-restful](https://github.com/flask-restful/flask-restful/)  
    - [pymysql](https://pymysql.readthedocs.io/en/latest/)  
-   - [pyyaml](https://pyyaml.org/wiki/PyYAMLDocumentation) (For the swagger generation)
-   - [pip-tools](https://github.com/jazzband/pip-tools) (For generating requirements.txt)
+   - [apispec](https://apispec.readthedocs.io/en/latest/) (For the swagger generation)
+   - [pip-tools](https://github.com/jazzband/pip-tools) (For generating
+    requirements.txt)
+   - [python-icat](https://python-icat.readthedocs.io/en/stable) (For ICAT backend)
+    
+
 
 ## Setup and running the API   
 The database connection needs to be set up first. This is set in config.json, an example
@@ -196,7 +202,7 @@ documentation from `flask-restful` functions.
 ## Running Tests
 To run the tests use `python -m unittest discover`
 
-## Linter
+## Code Formatter
 When writing code for this repository, [Black](https://black.readthedocs.io/en/stable/)
 is used as the code linter/formatter to ensure the code is kept Pythonic. Installing
 the dev requirements will ensure this package is installed. This repository uses the

--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,4 @@ pymysql == 0.9.3
 flask-cors == 3.0.8
 apispec == 3.3.0
 flask-swagger-ui == 3.25.0
-pyyaml == 5.1.2
+python-icat == 0.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
 markupsafe==1.1.1         # via jinja2
 pymysql==0.9.3            # via -r requirements.in
+python-icat==0.17.0       # via -r requirements.in
 pytz==2019.2              # via flask-restful
-pyyaml==5.1.2             # via -r requirements.in
 six==1.12.0               # via flask-cors, flask-restful
 sqlalchemy==1.3.8         # via -r requirements.in
 werkzeug==0.16.0          # via flask


### PR DESCRIPTION
This PR will close #134.

This updates the documentation regarding Swagger generation, so it now references the use of `apispec`. There are also some miscellaneous changes in `README.md` that I thought were worth improving while I was there. Not too much else to say I don't think :)