### PR TITLE
Fix Exception Handling for Non-Debug Mode

### DIFF
--- a/common/icat/helpers.py
+++ b/common/icat/helpers.py
@@ -487,9 +487,7 @@ def get_facility_cycles_for_instrument(
     log.info("Getting a list of facility cycles from the specified instrument for ISIS")
 
     query_aggregate = "COUNT:DISTINCT" if count_query else "DISTINCT"
-    query = ICATQuery(
-        client, "FacilityCycle", aggregate=query_aggregate
-    )
+    query = ICATQuery(client, "FacilityCycle", aggregate=query_aggregate)
 
     instrument_id_check = PythonICATWhereFilter(
         "facility.instruments.id", instrument_id, "eq"
@@ -572,9 +570,7 @@ def get_investigations_for_instrument_in_facility_cycle(
     )
 
     query_aggregate = "COUNT:DISTINCT" if count_query else "DISTINCT"
-    query = ICATQuery(
-        client, "Investigation", aggregate=query_aggregate
-    )
+    query = ICATQuery(client, "Investigation", aggregate=query_aggregate)
 
     instrument_id_check = PythonICATWhereFilter(
         "facility.instruments.id", instrument_id, "eq"

--- a/common/icat/query.py
+++ b/common/icat/query.py
@@ -15,12 +15,7 @@ log = logging.getLogger()
 
 class ICATQuery:
     def __init__(
-        self,
-        client,
-        entity_name,
-        conditions=None,
-        aggregate=None,
-        includes=None,
+        self, client, entity_name, conditions=None, aggregate=None, includes=None,
     ):
         """
         Create a Query object within Python ICAT 
@@ -58,7 +53,6 @@ class ICATQuery:
                 " suggesting an invalid argument"
             )
 
-
     def execute_query(self, client, return_json_formattable=False):
         """
         Execute the ICAT Query object and return in the format specified by the
@@ -93,10 +87,7 @@ class ICATQuery:
                 count_query = True
                 log.debug("This ICATQuery is used for COUNT purposes")
 
-        if (
-            self.query.aggregate == "DISTINCT"
-            and not count_query
-        ):
+        if self.query.aggregate == "DISTINCT" and not count_query:
             log.info("Extracting the distinct fields from query's conditions")
             # Check query's conditions for the ones created by the distinct filter
             distinct_attributes = self.iterate_query_conditions_for_distinctiveness()

--- a/src/main.py
+++ b/src/main.py
@@ -35,18 +35,21 @@ spec = APISpec(
     security=[{"session_id": []}],
 )
 
+
+class CustomErrorHandledApi(Api):
+    """
+    This class overrides `handle_error` function from the API class from `flask_restful`
+    to correctly return response codes and exception messages from uncaught exceptions
+    """
+
+    def handle_error(self, e):
+        return str(e), e.status_code
+
+
 app = Flask(__name__)
 cors = CORS(app)
 app.url_map.strict_slashes = False
-api = Api(app)
-
-
-def handle_error(e):
-    return str(e), e.status_code
-
-
-app.register_error_handler(ApiError, handle_error)
-
+api = CustomErrorHandledApi(app)
 
 swaggerui_blueprint = get_swaggerui_blueprint(
     "", "/openapi.json", config={"app_name": "DataGateway API OpenAPI Spec"},


### PR DESCRIPTION
This PR will close #147.

As per #147, exceptions weren't handled correctly in terms of response code & messages when debug mode wasn't used. Any uncaught exception would result in a 500, even if it should be a 400 (as an example). This change implements its own version of `flask_restful`'s `Api` class and overrides `handle_error()`. The issue was our own `handle_error()` was being registered with the Flask app, not the `api` object for Flask Restful.

I guess to test, try to break the API! I found this request should give a 400 on the ICAT backend:
`http://{{datagateway-api}}/usergroups/4`

Request Body:
```
{
    "createId": "simple/root"
}
```