### PR TITLE
Add NOT Like Operator to WHERE Filter

### DIFF
--- a/datagateway_api/common/database/filters.py
+++ b/datagateway_api/common/database/filters.py
@@ -77,6 +77,8 @@ class DatabaseWhereFilter(WhereFilter):
             query.base_query = query.base_query.filter(field != self.value)
         elif self.operation == "like":
             query.base_query = query.base_query.filter(field.like(f"%{self.value}%"))
+        elif self.operation == "nlike":
+            query.base_query = query.base_query.filter(field.notlike(f"%{self.value}%"))
         elif self.operation == "lt":
             query.base_query = query.base_query.filter(field < self.value)
         elif self.operation == "lte":

--- a/datagateway_api/common/icat/filters.py
+++ b/datagateway_api/common/icat/filters.py
@@ -48,6 +48,10 @@ class PythonICATWhereFilter(WhereFilter):
             where_filter = self.create_condition(self.field, "!=", self.value)
         elif self.operation == "like":
             where_filter = self.create_condition(self.field, "like", f"%{self.value}%")
+        elif self.operation == "nlike":
+            where_filter = self.create_condition(
+                self.field, "not like", f"%{self.value}%",
+            )
         elif self.operation == "lt":
             where_filter = self.create_condition(self.field, "<", self.value)
         elif self.operation == "lte":

--- a/test/db/test_query_filter_factory.py
+++ b/test/db/test_query_filter_factory.py
@@ -64,6 +64,7 @@ class TestQueryFilterFactory:
             pytest.param({"where": {"ID": {"gte": "1"}}}, id="gte operator"),
             pytest.param({"where": {"ID": {"in": ["1", "2", "3"]}}}, id="in operator"),
             pytest.param({"where": {"ID": {"like": "3"}}}, id="like operator"),
+            pytest.param({"where": {"ID": {"nlike": "3"}}}, id="not like operator"),
             pytest.param({"where": {"ID": {"lt": "1"}}}, id="lt operator"),
             pytest.param({"where": {"ID": {"lte": "1"}}}, id="lte operator"),
         ],

--- a/test/icat/filters/test_where_filter.py
+++ b/test/icat/filters/test_where_filter.py
@@ -12,6 +12,7 @@ class TestICATWhereFilter:
             pytest.param("eq", 5, "= '5'", id="equal"),
             pytest.param("ne", 5, "!= 5", id="not equal"),
             pytest.param("like", 5, "like '%5%'", id="like"),
+            pytest.param("nlike", 5, "not like '%5%'", id="not like"),
             pytest.param("lt", 5, "< '5'", id="less than"),
             pytest.param("lte", 5, "<= '5'", id="less than or equal"),
             pytest.param("gt", 5, "> '5'", id="greater than"),


### PR DESCRIPTION
This PR will close #193

## Description
As per the issue, there is a request in DataGateway for users to filter by data not containing a particular value. I've added this functionality on both backends by adding a new operator for the where filter. There are two extra tests that test this particular operator of the where filter too.

## Testing instructions
`http://{{datagateway-api}}/investigations?where={"TITLE": {"nlike":"dog"}}` should return a list of investigations where "dog" isn't in the title.

- [x] Review code
- [ ] Check the added tests pass

## Agile board tracking
connect to #193 
