### PR TITLE
Fix 404s on Codecov File Views

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -57,17 +57,15 @@ jobs:
 
     - name: Checkout DataGateway API
       uses: actions/checkout@v2
-      with:
-        path: datagateway-api
 
     # Prep for using the API for tests
     - name: Create log file
       run: touch logs.log
     - name: Configure log file location
       run: echo "`jq -r --arg REPO_DIR "$GITHUB_WORKSPACE/logs.log" \
-        '.log_location=$REPO_DIR' datagateway-api/config.json.example`" > datagateway-api/config.json.example
+        '.log_location=$REPO_DIR' config.json.example`" > config.json.example
     - name: Create config.json
-      run: cp datagateway-api/config.json.example datagateway-api/config.json
+      run: cp config.json.example config.json
 
     # Install Nox, Poetry and API's dependencies
     - name: Install Nox
@@ -75,21 +73,18 @@ jobs:
     - name: Install Poetry
       run: pip install poetry==1.1.4
     - name: Install dependencies
-      run: cd datagateway-api/ && poetry install
+      run: poetry install
 
     - name: Add dummy data to icatdb
       run: |
-        cd datagateway-api && poetry run python -m util.icat_db_generator -s 4 -y 3
+        poetry run python -m util.icat_db_generator -s 4 -y 3
 
     # Run Nox tests session, saves and uploads a coverage report to codecov
     - name: Run Nox tests session
-      run: cd datagateway-api && nox -s tests -- --cov=datagateway_api --cov-report=xml
+      run: nox -s tests -- --cov=datagateway_api --cov-report=xml
     - name: Upload code coverage report
       if: matrix.python-version == '3.6'
       uses: codecov/codecov-action@v1
-      with:
-        directory: ./datagateway-api
-        gcov_root_dir: ./datagateway-api
 
   linting:
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -83,12 +83,13 @@ jobs:
 
     # Run Nox tests session, saves and uploads a coverage report to codecov
     - name: Run Nox tests session
-      run: nox -s tests -f datagateway-api/noxfile.py -- --cov=datagateway_api --cov-report=xml
+      run: cd datagateway-api && nox -s tests -- --cov=datagateway_api --cov-report=xml
     - name: Upload code coverage report
       if: matrix.python-version == '3.6'
       uses: codecov/codecov-action@v1
       with:
         directory: ./datagateway-api
+        gcov_root_dir: ./datagateway-api
 
   linting:
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -97,8 +97,6 @@ jobs:
         architecture: x64
     - name: Checkout DataGateway API
       uses: actions/checkout@v2
-      with:
-        path: datagateway-api
 
     - name: Install Nox
       run: pip install nox==2020.8.22
@@ -106,7 +104,7 @@ jobs:
       run: pip install poetry==1.1.4
 
     - name: Run Nox lint session
-      run: nox -s lint -f datagateway-api/noxfile.py
+      run: nox -s lint
 
   formatting:
     runs-on: ubuntu-16.04
@@ -119,8 +117,6 @@ jobs:
         architecture: x64
     - name: Checkout DataGateway API
       uses: actions/checkout@v2
-      with:
-        path: datagateway-api
 
     - name: Install Nox
       run: pip install nox==2020.8.22
@@ -128,7 +124,7 @@ jobs:
       run: pip install poetry==1.1.4
 
     - name: Run Nox black session
-      run: nox -s black -f datagateway-api/noxfile.py
+      run: nox -s black
 
   safety:
     runs-on: ubuntu-16.04
@@ -141,8 +137,6 @@ jobs:
         architecture: x64
     - name: Checkout DataGateway API
       uses: actions/checkout@v2
-      with:
-        path: datagateway-api
 
     - name: Install Nox
       run: pip install nox==2020.8.22
@@ -150,4 +144,4 @@ jobs:
       run: pip install poetry==1.1.4
 
     - name: Run Nox safety session
-      run: nox -s safety -f datagateway-api/noxfile.py
+      run: nox -s safety


### PR DESCRIPTION
This PR will close #203 

## Description
As per the linked issue, there was a bug regarding Codecov and accessing the API's files within the codecov portal to see the colourful display of test coverage (screenshot of the issue below). By not providing a path for the checkout action within the CI build workflow, this maps the path on the runner to the relative path on the repo. This is a slightly different solution to the 'path fixing' I identified in the issue, but changing the repo path on the CI runner has turned out to be the simpler solution. This means you can see coverage data in a colourful format!

![image](https://user-images.githubusercontent.com/32678030/106649928-25dc0300-658a-11eb-9c99-19c811917c9d.png)

## Testing Instructions
Viewing any of the files using the following link (codecov on this branch) will allow you to view them with coverage data:
https://codecov.io/gh/ral-facilities/datagateway-api/tree/bugfix%2Fcodecov-path-fixing/datagateway_api

- [x] Review code
- [x] Check GitHub Actions build
- [x] Review changes to test coverage
- [x] You should be able to view a copy of each file, displaying code coverage data - test link provided above
- [x] Codecov PR comment should be present and correct on this PR

## Agile Board Tracking
Connect to #203