### PR TITLE
Don't write to openapi.yaml when generate_swagger set to false

### DIFF
--- a/datagateway_api/src/api_start_utils.py
+++ b/datagateway_api/src/api_start_utils.py
@@ -160,9 +160,9 @@ def openapi_config(spec):
             for endpoint_name in sorted(entity_data.keys()):
                 entity_data.move_to_end(endpoint_name)
 
-    openapi_spec_path = Path(__file__).parent / "swagger/openapi.yaml"
-    with open(openapi_spec_path, "w") as f:
-        f.write(spec.to_yaml())
+        openapi_spec_path = Path(__file__).parent / "swagger/openapi.yaml"
+        with open(openapi_spec_path, "w") as f:
+            f.write(spec.to_yaml())
 
 
 def create_openapi_endpoint(app, api_spec):


### PR DESCRIPTION
Indents the bit of code that writes to openapi.yaml so that it falls under the check of whether generate_swagger is set.
