### PR TITLE
Make Flask Reloader Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,13 @@ PowerShell:
 > flask run
 ```
 
+The Flask app can be configured so that code changes are monitored and the server will
+reload itself when a change is detected. This setting can be toggled using
+`flask_reloader` in `config.json`. This is useful for development purposes. It should be
+noted that when this setting is enabled, the API will go through the startup process
+twice. In the case of the ICAT backend, this could dramatically increase startup time if
+the API is configured with a large initial client pool size.
+
 
 ## Authentication
 Each request requires a valid session ID to be provided in the Authorization header.

--- a/datagateway_api/common/config.py
+++ b/datagateway_api/common/config.py
@@ -40,6 +40,12 @@ class Config(object):
         except KeyError:
             sys.exit("Missing config value, DB_URL")
 
+    def is_flask_reloader(self):
+        try:
+            return self.config["flask_reloader"]
+        except KeyError:
+            sys.exit("Missing config value, flask_reloader")
+
     def get_icat_url(self):
         try:
             return self.config["ICAT_URL"]

--- a/datagateway_api/config.json.example
+++ b/datagateway_api/config.json.example
@@ -1,6 +1,7 @@
 {
   "backend": "db",
   "DB_URL": "mysql+pymysql://icatdbuser:icatdbuserpw@localhost:3306/icatdb",
+  "flask_reloader": false,
   "ICAT_URL": "https://localhost:8181",
   "icat_check_cert": false,
   "log_level": "WARN",

--- a/datagateway_api/src/main.py
+++ b/datagateway_api/src/main.py
@@ -23,5 +23,8 @@ create_openapi_endpoint(app, spec)
 
 if __name__ == "__main__":
     app.run(
-        host=config.get_host(), port=config.get_port(), debug=config.is_debug_mode(),
+        host=config.get_host(),
+        port=config.get_port(),
+        debug=config.is_debug_mode(),
+        use_reloader=config.is_flask_reloader(),
     )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -42,6 +42,16 @@ class TestGetDBURL:
             invalid_config.get_db_url()
 
 
+class TestIsFlaskReloader:
+    def test_valid_flask_reloader(self, valid_config):
+        flask_reloader = valid_config.is_flask_reloader()
+        assert flask_reloader is False
+
+    def test_invalid_flask_reloader(self, invalid_config):
+        with pytest.raises(SystemExit):
+            invalid_config.is_flask_reloader()
+
+
 class TestICATURL:
     def test_valid_icat_url(self, valid_config):
         icat_url = valid_config.get_icat_url()


### PR DESCRIPTION
This PR will close #214 

## Description
As per the linked issue, this is a tiny change just to make the reloader configurable for the flask app. This reloader is great for updating the Flask app when code changes are detected, but startup is done twice. With the new client handling stuff incoming, I've experienced the reloading on startup can be a pain if the inital pool size is set to a high amount (doubles the startup time for no good reason).

In the linked issue, I mentioned debug mode affecting whether the reloader was enabled or not. Now this is being explicitly set in `app.run()`, there is no link between debug mode and the reloader - the configured setting overrules this behaviour.

## Testing Instructions
When the setting is set to `true`, the reloader should respond to code changes. This can also be tested by seeing whether the `INFO -  * Restarting with stat` log message appears in `logs.log` when starting up the API. When in the ICAT backend and running with the `icat_check_cert` setting disabled, you should see the `InsecureRequestWarning` message twice in the console. The opposite (i.e. no reloading) should occur when the reloader is disabled

- [x] Check toggling configured setting actually has an impact
- [x] Check GitHub Actions build
- [x] Review changes to test coverage
- [x] Check the documentation makes sense

## Agile Board Tracking
Connect to #214 
