### PR TITLE
Fix Broken CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,6 +50,10 @@ jobs:
       run: |
         sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" icat-ansible/group_vars/all/vars.yml
 
+    # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
+    - name: Change hostname to localhost
+      run: sudo hostname -b localhost
+
     # Create local instance of ICAT
     - name: Run ICAT Ansible Playbook
       run: |


### PR DESCRIPTION
This PR will close #220 

## Description
This change fixes the CI which started to break last week. Forcing the hostname seems to have fixed things - ICAT seemed to pick up something along the lines of `fv-az202-715` before which then caused a load of unknown host exceptions.

## Testing Instructions
I guess the testing should by GitHub running the workflow on this PR. I've also done 3 separate runs using this change, to ensure it's reliable. They all passed, you can find them at the links below:

[Run 1](https://github.com/ral-facilities/datagateway-api/actions/runs/763565530)
[Run 2](https://github.com/ral-facilities/datagateway-api/actions/runs/763593589)
[Run 3](https://github.com/ral-facilities/datagateway-api/actions/runs/763658274)

- [x] Review code
- [x] Check GitHub Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile Board Tracking
Connect to #220 
