### PR TITLE
Add Timezone Data to DB Backend

### DIFF
--- a/datagateway_api/common/constants.py
+++ b/datagateway_api/common/constants.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
+from dateutil.tz import tzlocal
+
 
 class Constants:
     PYTHON_ICAT_DISTNCT_CONDITION = "!= null"
-    TEST_MOD_CREATE_DATETIME = datetime(2000, 1, 1)
+    TEST_MOD_CREATE_DATETIME = datetime(2000, 1, 1, tzinfo=tzlocal())

--- a/datagateway_api/common/database/models.py
+++ b/datagateway_api/common/database/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from decimal import Decimal
 import enum
 
+from dateutil.tz import tzlocal
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -20,6 +21,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.collections import InstrumentedList
 
+from datagateway_api.common.date_handler import DateHandler
 from datagateway_api.common.exceptions import DatabaseError, FilterError
 
 Base = declarative_base()
@@ -78,7 +80,9 @@ class EntityHelper(ABC):
         :return: The converted field
         """
         if isinstance(field, datetime):
-            return str(field)
+            # Add timezone info to match ICAT backend
+            field = field.replace(tzinfo=tzlocal())
+            return DateHandler.datetime_object_to_str(field)
         elif isinstance(field, Decimal):
             return float(field)
         else:

--- a/datagateway_api/common/icat/helpers.py
+++ b/datagateway_api/common/icat/helpers.py
@@ -3,6 +3,7 @@ from functools import wraps
 import logging
 
 from cachetools import cached
+from dateutil.tz import tzlocal
 from icat.entities import getTypeMap
 from icat.exception import (
     ICATInternalError,
@@ -114,7 +115,7 @@ def get_session_details_helper(client):
     """
     session_time_remaining = client.getRemainingMinutes()
     session_expiry_time = (
-        datetime.now() + timedelta(minutes=session_time_remaining)
+        datetime.now(tzlocal()) + timedelta(minutes=session_time_remaining)
     ).replace(microsecond=0)
     username = client.getUserName()
 

--- a/test/icat/conftest.py
+++ b/test/icat/conftest.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timezone
+from datetime import datetime
 import uuid
 
+from dateutil.tz import tzlocal
 from flask import Flask
 from icat.client import Client
 from icat.exception import ICATNoObjectError
@@ -49,10 +50,10 @@ def create_investigation_test_data(client, num_entities=1):
             f"Test data for the Python ICAT Backend on DataGateway API {i}"
         )
         investigation.startDate = datetime(
-            year=2020, month=1, day=4, hour=1, minute=1, second=1, tzinfo=timezone.utc,
+            year=2020, month=1, day=4, hour=1, minute=1, second=1, tzinfo=tzlocal(),
         )
         investigation.endDate = datetime(
-            year=2020, month=1, day=8, hour=1, minute=1, second=1, tzinfo=timezone.utc,
+            year=2020, month=1, day=8, hour=1, minute=1, second=1, tzinfo=tzlocal(),
         )
         # UUID visit ID means uniquesness constraint should always be met
         investigation.visitId = str(uuid.uuid1())
@@ -112,10 +113,10 @@ def isis_specific_endpoint_data(icat_client):
     facility_cycle = icat_client.new("facilityCycle")
     facility_cycle.name = "Test cycle for DataGateway API testing"
     facility_cycle.startDate = datetime(
-        year=2020, month=1, day=1, hour=1, minute=1, second=1, tzinfo=timezone.utc,
+        year=2020, month=1, day=1, hour=1, minute=1, second=1, tzinfo=tzlocal(),
     )
     facility_cycle.endDate = datetime(
-        year=2020, month=2, day=1, hour=1, minute=1, second=1, tzinfo=timezone.utc,
+        year=2020, month=2, day=1, hour=1, minute=1, second=1, tzinfo=tzlocal(),
     )
     facility_cycle.facility = icat_client.get("Facility", 1)
     facility_cycle.create()

--- a/test/icat/test_query.py
+++ b/test/icat/test_query.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
+from dateutil.tz import tzlocal
 from icat.entity import Entity
 import pytest
 
@@ -364,7 +365,7 @@ class TestICATQuery:
                         hour=1,
                         minute=1,
                         second=1,
-                        tzinfo=timezone.utc,
+                        tzinfo=tzlocal(),
                     ),
                 ),
                 {"startDate": "2020-01-04 01:01:01+00:00"},

--- a/test/icat/test_session_handling.py
+++ b/test/icat/test_session_handling.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 
+from dateutil.tz import tzlocal
 from icat.client import Client
 import pytest
 
 from datagateway_api.common.config import APIConfigOptions, config
+from datagateway_api.common.date_handler import DateHandler
 from datagateway_api.common.icat.filters import PythonICATWhereFilter
 
 
@@ -15,10 +17,11 @@ class TestSessionHandling:
             "/sessions", headers=valid_icat_credentials_header,
         )
 
-        session_expiry_datetime = datetime.strptime(
-            session_details.json["expireDateTime"], "%Y-%m-%d %H:%M:%S",
+        session_expiry_datetime = DateHandler.str_to_datetime_object(
+            session_details.json["expireDateTime"],
         )
-        current_datetime = datetime.now()
+
+        current_datetime = datetime.now(tzlocal())
         time_diff = abs(session_expiry_datetime - current_datetime)
         time_diff_minutes = time_diff.seconds / 60
 


### PR DESCRIPTION
This PR will close #225 

## Description
This change helps to make the DB backend become more aligned with the ICAT backend by having timezones when displaying datetimes on the API. 

It seems the DB backend doesn't actually use timezones anywhere - I tried setting the `timezone` flag as pointed out in the [docs](https://docs.sqlalchemy.org/en/14/core/type_basics.html#sqlalchemy.types.DateTime) but that didn't have any impact. Instead, I've made the DB backend display the local timezone for the API. This seems to be the best compromise I could find to make the two backends aligned.

The DB backend now uses the `DateHandler` so will have the same format for datetimes as the ICAT backend.

I also noticed that the get session details endpoint doesn't use timezones on the ICAT backend. I fixed that on 9b2dc7d.

## Testing Instructions
Check that both backends have display datetime in the same format (including the timezone part of the output)

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage

## Agile Board Tracking
Connect to #225 
