### PR TITLE
Allow related entities on DB distinct filter

### DIFF
--- a/datagateway_api/common/database/filters.py
+++ b/datagateway_api/common/database/filters.py
@@ -2,7 +2,6 @@ import logging
 
 from sqlalchemy import asc, desc
 
-from datagateway_api.common.database import models
 from datagateway_api.common.exceptions import FilterError, MultipleIncludeError
 from datagateway_api.common.filters import (
     DistinctFieldFilter,

--- a/datagateway_api/common/database/filters.py
+++ b/datagateway_api/common/database/filters.py
@@ -31,12 +31,6 @@ class DatabaseFilterUtilities:
     """
 
     def __init__(self):
-        """
-        The `distinct_join_flag` tracks if JOINs need to be added to the query - on a
-        distinct filter, if there's no unrelated fields (i.e. no fields with a
-        `related_depth` of 1), adding JOINs to the query (using `add_query_join()`)
-        will result in a `sqlalchemy.exc.InvalidRequestError`
-        """
         self.field = None
         self.related_field = None
         self.related_related_field = None

--- a/datagateway_api/common/database/filters.py
+++ b/datagateway_api/common/database/filters.py
@@ -124,7 +124,6 @@ class DatabaseFilterUtilities:
 
 class DatabaseWhereFilter(WhereFilter, DatabaseFilterUtilities):
     def __init__(self, field, value, operation):
-        # TODO - Apply any 'pythonic' solution here too
         WhereFilter.__init__(self, field, value, operation)
         DatabaseFilterUtilities.__init__(self)
 
@@ -160,8 +159,6 @@ class DatabaseWhereFilter(WhereFilter, DatabaseFilterUtilities):
 
 class DatabaseDistinctFieldFilter(DistinctFieldFilter, DatabaseFilterUtilities):
     def __init__(self, fields):
-        # TODO - what's the Pythonic solution here?
-        # super().__init__(fields)
         DistinctFieldFilter.__init__(self, fields)
         DatabaseFilterUtilities.__init__(self)
 

--- a/datagateway_api/common/database/filters.py
+++ b/datagateway_api/common/database/filters.py
@@ -18,6 +18,85 @@ from datagateway_api.common.helpers import get_entity_object_from_name
 log = logging.getLogger()
 
 
+class DatabaseFilterUtilities:
+    """
+    Class containing utility functions used in the WhereFilter and DistinctFilter
+
+    In this class, the terminology of 'included entities' has been made more generic to
+    'related entities'. When these functions are used with the WhereFilter, the related
+    entities are in fact included entities (entities which are also present in the input
+    of an include filter in the same request). However, when these functions are used
+    with the DistinctFilter, they are related entities, not included entities as there's
+    no requirement for the entity names to also be present in an include filter (this is
+    to match the ICAT backend)
+    """
+
+    def __init__(self):
+        self.related_field = None
+        self.related_related_field = None
+
+    def _extract_filter_fields(self, field):
+        """
+        Extract the related fields names and put them into separate variables
+
+        :param field: ICAT field names, separated by dots
+        :type field: :class:`str`
+        :raises ValueError: If the maximum related/included depth is exceeded
+        """
+
+        fields = field.split(".")
+        related_depth = len(fields)
+
+        log.debug("Fields: %s, Related Depth: %d", fields, related_depth)
+
+        if related_depth == 1:
+            self.field = fields[0]
+        elif related_depth == 2:
+            self.field = fields[0]
+            self.related_field = fields[1]
+        elif related_depth == 3:
+            self.field = fields[0]
+            self.related_field = fields[1]
+            self.related_related_field = fields[2]
+        else:
+            raise ValueError(f"Maximum related depth exceeded. {field}'s depth > 3")
+
+        # TODO - Remove if not needed
+        # return (field, related_field, related_related_field)
+
+    def _add_query_join(self, query):
+        """
+        Fetches the appropriate entity model based on the contents of `self.field` and
+        adds any required JOINs to the query if any related fields have been used in the
+        filter
+
+        :param query: The query to have filters applied to
+        :type query: :class:`datagateway_api.common.database.helpers.[QUERY]`
+        :return: Entity model of the field (usually the field relating to the endpoint
+            the request is coming from)
+        """
+        try:
+            field = getattr(query.table, self.field)
+        except AttributeError:
+            raise FilterError(
+                f"Unknown attribute {self.field} on table {query.table.__name__}",
+            )
+
+        if self.related_related_field:
+            included_table = getattr(models, self.field)
+            included_included_table = getattr(models, self.related_field)
+            query.base_query = query.base_query.join(included_table).join(
+                included_included_table,
+            )
+            field = getattr(included_included_table, self.related_related_field)
+        elif self.related_field:
+            included_table = get_entity_object_from_name(self.field)
+            query.base_query = query.base_query.join(included_table)
+            field = getattr(included_table, self.related_field)
+
+        return field
+
+
 class DatabaseWhereFilter(WhereFilter):
     def __init__(self, field, value, operation):
         super().__init__(field, value, operation)
@@ -95,17 +174,24 @@ class DatabaseWhereFilter(WhereFilter):
             )
 
 
-class DatabaseDistinctFieldFilter(DistinctFieldFilter):
+class DatabaseDistinctFieldFilter(DistinctFieldFilter, DatabaseFilterUtilities):
     def __init__(self, fields):
-        super().__init__(fields)
+        # TODO - what's the Pythonic solution here?
+        # super().__init__(fields)
+        DistinctFieldFilter.__init__(self, fields)
+        DatabaseFilterUtilities.__init__(self)
 
     def apply_filter(self, query):
         query.is_distinct_fields_query = True
         try:
-            self.fields = [getattr(query.table, field) for field in self.fields]
+            distinct_fields = []
+            for field_name in self.fields:
+                self._extract_filter_fields(field_name)
+                field = self._add_query_join(query)
+                distinct_fields.append(field)
         except AttributeError:
             raise FilterError("Bad field requested")
-        query.base_query = query.session.query(*self.fields).distinct()
+        query.base_query = query.session.query(*distinct_fields).distinct()
 
 
 class DatabaseOrderFilter(OrderFilter):

--- a/datagateway_api/common/database/helpers.py
+++ b/datagateway_api/common/database/helpers.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from datagateway_api.common.helpers import map_distinct_attributes_to_results
 import datetime
 from functools import wraps
 import logging
@@ -26,6 +25,7 @@ from datagateway_api.common.exceptions import (
     MissingRecordError,
 )
 from datagateway_api.common.filter_order_handler import FilterOrderHandler
+from datagateway_api.common.helpers import map_distinct_attributes_to_results
 
 
 log = logging.getLogger()

--- a/datagateway_api/common/database/helpers.py
+++ b/datagateway_api/common/database/helpers.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datagateway_api.common.helpers import map_distinct_attributes_to_results
 import datetime
 from functools import wraps
 import logging
@@ -7,6 +8,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import aliased
 
 from datagateway_api.common.database.filters import (
+    DatabaseDistinctFieldFilter,
     DatabaseIncludeFilter as IncludeFilter,
     DatabaseWhereFilter as WhereFilter,
 )
@@ -278,7 +280,7 @@ def get_filtered_read_query_results(filter_handler, filters, query):
     filter_handler.apply_filters(query)
     results = query.get_all_results()
     if query.is_distinct_fields_query:
-        return _get_distinct_fields_as_dicts(results)
+        return _get_distinct_fields_as_dicts(filters, results)
     if query.include_related_entities:
         return _get_results_with_include(filters, results)
     return list(map(lambda x: x.to_dict(), results))
@@ -298,7 +300,7 @@ def _get_results_with_include(filters, results):
             return [x.to_nested_dict(query_filter.included_filters) for x in results]
 
 
-def _get_distinct_fields_as_dicts(results):
+def _get_distinct_fields_as_dicts(filters, results):
     """
     Given a list of column results return a list of dictionaries where each column name
     is the key and the column value is the dictionary key value
@@ -306,10 +308,16 @@ def _get_distinct_fields_as_dicts(results):
     :param results: A list of sql alchemy result objects
     :return: A list of dictionary representations of the sqlalchemy result objects
     """
+    distinct_fields = []
+    for query_filter in filters:
+        if type(query_filter) is DatabaseDistinctFieldFilter:
+            distinct_fields.extend(query_filter.fields)
+
     dictionaries = []
     for result in results:
-        dictionary = {k: getattr(result, k) for k in result.keys()}
+        dictionary = map_distinct_attributes_to_results(distinct_fields, result)
         dictionaries.append(dictionary)
+
     return dictionaries
 
 

--- a/datagateway_api/common/helpers.py
+++ b/datagateway_api/common/helpers.py
@@ -146,12 +146,11 @@ def map_distinct_attributes_to_results(distinct_attributes, query_result):
     :param query_result: Results fetched from a database query (backend independent due
         to the data structure of this parameter)
     :type query_result: :class:`tuple` or :class:`list` when a single attribute is
-        given from ICAT backend, TODO
+        given from ICAT backend, or :class:`sqlalchemy.engine.row.Row` when used on the
+        DB backend
     :return: Dictionary of attribute names paired with the results, ready to be
         returned to the user
     """
-    log.debug(f"Query Result Type: {type(query_result)}")
-
     result_dict = {}
     for attr_name, data in zip(distinct_attributes, query_result):
         # Splitting attribute names in case it's from a related entity

--- a/datagateway_api/common/helpers.py
+++ b/datagateway_api/common/helpers.py
@@ -1,4 +1,3 @@
-from datagateway_api.common.date_handler import DateHandler
 from datetime import datetime
 from functools import wraps
 import json
@@ -9,6 +8,7 @@ from flask_restful import reqparse
 from sqlalchemy.exc import IntegrityError
 
 from datagateway_api.common.database import models
+from datagateway_api.common.date_handler import DateHandler
 from datagateway_api.common.exceptions import (
     ApiError,
     AuthenticationError,

--- a/datagateway_api/common/helpers.py
+++ b/datagateway_api/common/helpers.py
@@ -3,6 +3,7 @@ from functools import wraps
 import json
 import logging
 
+from dateutil.tz.tz import tzlocal
 from flask import request
 from flask_restful import reqparse
 from sqlalchemy.exc import IntegrityError
@@ -157,6 +158,10 @@ def map_distinct_attributes_to_results(distinct_attributes, query_result):
         split_attr_name = attr_name.split(".")
 
         if isinstance(data, datetime):
+            # Workaround for when this function is used on DB backend, where usually
+            # `_make_serializable()` would fix tzinfo
+            if data.tzinfo is None:
+                data = data.replace(tzinfo=tzlocal())
             data = DateHandler.datetime_object_to_str(data)
 
         # Attribute name is from the 'origin' entity (i.e. not a related entity)

--- a/datagateway_api/common/icat/query.py
+++ b/datagateway_api/common/icat/query.py
@@ -1,3 +1,4 @@
+from datagateway_api.common.helpers import map_distinct_attributes_to_results
 from datetime import datetime
 import logging
 
@@ -123,9 +124,7 @@ class ICATQuery:
 
                     # Map distinct attributes and result
                     data.append(
-                        self.map_distinct_attributes_to_results(
-                            distinct_attributes, result,
-                        ),
+                        map_distinct_attributes_to_results(distinct_attributes, result),
                     )
                 elif not count_query:
                     dict_result = self.entity_to_dict(result, flat_query_includes)
@@ -197,75 +196,6 @@ class ICATQuery:
 
                 d[key] = entity_data
         return d
-
-    def map_distinct_attributes_to_results(self, distinct_attributes, query_result):
-        """
-        Maps the attribute names from a distinct filter onto the results given by the
-        query constructed and executed using Python ICAT
-
-        When selecting multiple (but not all) attributes in a JPQL query, the results
-        are returned in a list and not mapped to an entity object. As a result,
-        `entity_to_dict()` cannot be used as that function assumes an entity object
-        input. Within the API, selecting multiple attributes happens when a distinct
-        filter is applied to a request. This function is the alternative for processing
-        data ready for output
-
-        :param distinct_attributes: List of distinct attributes from the distinct
-            filter of the incoming request
-        :type distinct_attributes: :class:`list`
-        :param query_result: Results fetched from Python ICAT
-        :type query_result: :class:`tuple` or :class:`list` when a single attribute is
-            given
-        :return: Dictionary of attribute names paired with the results, ready to be
-            returned to the user
-        """
-        result_dict = {}
-        for attr_name, data in zip(distinct_attributes, query_result):
-            # Splitting attribute names in case it's from a related entity
-            split_attr_name = attr_name.split(".")
-
-            if isinstance(data, datetime):
-                data = DateHandler.datetime_object_to_str(data)
-
-            # Attribute name is from the 'origin' entity (i.e. not a related entity)
-            if len(split_attr_name) == 1:
-                result_dict[attr_name] = data
-            # Attribute name is a related entity, dictionary needs to be nested
-            else:
-                result_dict.update(self.map_nested_attrs({}, split_attr_name, data))
-
-        return result_dict
-
-    def map_nested_attrs(self, nested_dict, split_attr_name, query_data):
-        """
-        A function that can be called recursively to map attributes from related
-        entities to the associated data
-
-        :param nested_dict: Dictionary to insert data into
-        :type nested_dict: :class:`dict`
-        :param split_attr_name: List of parts to an attribute name, that have been split
-            by "."
-        :type split_attr_name: :class:`list`
-        :param query_data: Data to be added to the dictionary
-        :type query_data: :class:`str` or :class:`str`
-        :return: Dictionary to be added to the result dictionary
-        """
-        # Popping LHS of related attribute name to see if it's an attribute name or part
-        # of a path to a related entity
-        attr_name_pop = split_attr_name.pop(0)
-
-        # Related attribute name, ready to insert data into dictionary
-        if len(split_attr_name) == 0:
-            # at role, so put data in
-            nested_dict[attr_name_pop] = query_data
-        # Part of the path for related entity, need to recurse to get to attribute name
-        else:
-            nested_dict[attr_name_pop] = {}
-            self.map_nested_attrs(
-                nested_dict[attr_name_pop], split_attr_name, query_data,
-            )
-
-        return nested_dict
 
     def flatten_query_included_fields(self, includes):
         """

--- a/datagateway_api/common/icat/query.py
+++ b/datagateway_api/common/icat/query.py
@@ -1,4 +1,3 @@
-from datagateway_api.common.helpers import map_distinct_attributes_to_results
 from datetime import datetime
 import logging
 
@@ -8,6 +7,7 @@ from icat.query import Query
 
 from datagateway_api.common.date_handler import DateHandler
 from datagateway_api.common.exceptions import PythonICATError
+from datagateway_api.common.helpers import map_distinct_attributes_to_results
 
 
 log = logging.getLogger()

--- a/test/db/endpoints/test_get_with_filters.py
+++ b/test/db/endpoints/test_get_with_filters.py
@@ -55,6 +55,19 @@ class TestDBGetWithFilters:
                 id="Single unrelated distinct field",
             ),
             pytest.param(
+                '"investigationInstruments.createTime"',
+                [
+                    {
+                        "investigationInstruments": {
+                            "createTime": DateHandler.datetime_object_to_str(
+                                Constants.TEST_MOD_CREATE_DATETIME,
+                            ),
+                        },
+                    },
+                ],
+                id="Single related distinct field",
+            ),
+            pytest.param(
                 '["createTime", "investigationInstruments.createTime"]',
                 [
                     {
@@ -68,7 +81,21 @@ class TestDBGetWithFilters:
                         },
                     },
                 ],
-                id="List containing related distinct field",
+                id="Single related distinct field with unrelated field",
+            ),
+            pytest.param(
+                '["investigationInstruments.createTime", "facility.id"]',
+                [
+                    {
+                        "facility": {"id": 1},
+                        "investigationInstruments": {
+                            "createTime": DateHandler.datetime_object_to_str(
+                                Constants.TEST_MOD_CREATE_DATETIME,
+                            ),
+                        },
+                    },
+                ],
+                id="Multiple related distinct fields",
             ),
             pytest.param(
                 '["createTime", "investigationInstruments.createTime", "facility.id"]',
@@ -85,7 +112,7 @@ class TestDBGetWithFilters:
                         },
                     },
                 ],
-                id="Multiple related distinct fields",
+                id="Multiple related distinct fields with unrelated field",
             ),
         ],
     )

--- a/test/db/endpoints/test_get_with_filters.py
+++ b/test/db/endpoints/test_get_with_filters.py
@@ -28,7 +28,7 @@ class TestDBGetWithFilters:
         assert test_response.json == []
 
     @pytest.mark.usefixtures("multiple_investigation_test_data_db")
-    def test_valid_get_with_filters_distinct(
+    def test_valid_get_with_filters_multiple_distinct(
         self, flask_test_app_db, valid_db_credentials_header,
     ):
         test_response = flask_test_app_db.get(
@@ -41,8 +41,7 @@ class TestDBGetWithFilters:
             {"title": f"Title for DataGateway API Testing (DB) {i}"} for i in range(5)
         ]
 
-        for title in expected:
-            assert title in test_response.json
+        assert test_response.json == expected
 
     def test_limit_skip_merge_get_with_filters(
         self,

--- a/test/db/test_database_filter_utilities.py
+++ b/test/db/test_database_filter_utilities.py
@@ -30,7 +30,7 @@ class TestDatabaseFilterUtilities:
     )
     def test_valid_extract_filter_fields(self, input_field, expected_fields):
         test_utility = DatabaseFilterUtilities()
-        test_utility._extract_filter_fields(input_field)
+        test_utility.extract_filter_fields(input_field)
 
         assert test_utility.field == expected_fields[0]
         assert test_utility.related_field == expected_fields[1]
@@ -40,7 +40,7 @@ class TestDatabaseFilterUtilities:
         test_utility = DatabaseFilterUtilities()
 
         with pytest.raises(ValueError):
-            test_utility._extract_filter_fields(
+            test_utility.extract_filter_fields(
                 "user.investigationUsers.investigation.summary",
             )
 
@@ -60,7 +60,7 @@ class TestDatabaseFilterUtilities:
         table = get_entity_object_from_name("Investigation")
 
         test_utility = DatabaseFilterUtilities()
-        test_utility._extract_filter_fields(input_field)
+        test_utility.extract_filter_fields(input_field)
 
         expected_query = ReadQuery(table)
         if test_utility.related_related_field:
@@ -79,7 +79,7 @@ class TestDatabaseFilterUtilities:
             expected_table = table
 
         with ReadQuery(table) as test_query:
-            test_utility._add_query_join(test_query)
+            test_utility.add_query_join(test_query)
 
         # Check the JOIN has been applied
         assert str(test_query.base_query) == str(expected_query.base_query)
@@ -98,7 +98,7 @@ class TestDatabaseFilterUtilities:
         table = get_entity_object_from_name("Investigation")
 
         test_utility = DatabaseFilterUtilities()
-        test_utility._extract_filter_fields(input_field)
+        test_utility.extract_filter_fields(input_field)
 
         if test_utility.related_related_field:
             expected_table = get_entity_object_from_name(test_utility.related_field)
@@ -108,7 +108,7 @@ class TestDatabaseFilterUtilities:
             expected_table = table
 
         with ReadQuery(table) as test_query:
-            output_field = test_utility._get_entity_model_for_filter(test_query)
+            output_field = test_utility.get_entity_model_for_filter(test_query)
 
         # Check the output is correct
         field_name_to_fetch = input_field.split(".")[-1]

--- a/test/db/test_database_filter_utilities.py
+++ b/test/db/test_database_filter_utilities.py
@@ -1,0 +1,104 @@
+import pytest
+
+from datagateway_api.common.database.filters import DatabaseFilterUtilities
+from datagateway_api.common.database.helpers import ReadQuery
+from datagateway_api.common.exceptions import FilterError
+from datagateway_api.common.helpers import get_entity_object_from_name
+
+
+class TestDatabaseFilterUtilities:
+    @pytest.mark.parametrize(
+        "input_field, expected_fields",
+        [
+            pytest.param("name", ("name", None, None), id="Unrelated field"),
+            pytest.param(
+                "facility.daysUntilRelease",
+                ("facility", "daysUntilRelease", None),
+                id="Related field matching ICAT schema name",
+            ),
+            pytest.param(
+                "FACILITY.daysUntilRelease",
+                ("FACILITY", "daysUntilRelease", None),
+                id="Related field matching database format (uppercase)",
+            ),
+            pytest.param(
+                "user.investigationUsers.role",
+                ("user", "investigationUsers", "role"),
+                id="Related related field (2 levels deep)",
+            ),
+        ],
+    )
+    def test_valid_extract_filter_fields(self, input_field, expected_fields):
+        test_utility = DatabaseFilterUtilities()
+        test_utility._extract_filter_fields(input_field)
+
+        assert test_utility.field == expected_fields[0]
+        assert test_utility.related_field == expected_fields[1]
+        assert test_utility.related_related_field == expected_fields[2]
+
+    def test_invalid_extract_filter_fields(self):
+        test_utility = DatabaseFilterUtilities()
+
+        with pytest.raises(ValueError):
+            test_utility._extract_filter_fields(
+                "user.investigationUsers.investigation.summary",
+            )
+
+    @pytest.mark.parametrize(
+        "input_field",
+        [
+            pytest.param("name", id="No related fields"),
+            pytest.param("facility.daysUntilRelease", id="Related field"),
+            pytest.param(
+                "investigationUsers.user.fullName", id="Related related field",
+            ),
+        ],
+    )
+    def test_valid_add_query_join(
+        self, flask_test_app_db, input_field,
+    ):
+        table = get_entity_object_from_name("Investigation")
+
+        test_utility = DatabaseFilterUtilities()
+        test_utility._extract_filter_fields(input_field)
+
+        expected_query = ReadQuery(table)
+        if test_utility.related_related_field:
+            expected_table = get_entity_object_from_name(test_utility.related_field)
+
+            included_table = get_entity_object_from_name(test_utility.field)
+            expected_query.base_query = expected_query.base_query.join(
+                included_table,
+            ).join(expected_table)
+        elif test_utility.related_field:
+            expected_table = get_entity_object_from_name(test_utility.field)
+
+            expected_query = ReadQuery(table)
+            expected_query.base_query = expected_query.base_query.join(expected_table)
+        else:
+            expected_table = table
+
+        with ReadQuery(table) as test_query:
+            output_field = test_utility._add_query_join(test_query)
+
+        # Check the JOIN has been applied
+        assert str(test_query.base_query) == str(expected_query.base_query)
+
+        # Check the output is correct
+        field_name_to_fetch = input_field.split(".")[-1]
+        assert output_field == getattr(expected_table, field_name_to_fetch)
+
+    def test_valid_get_field(self, flask_test_app_db):
+        table = get_entity_object_from_name("Investigation")
+
+        test_utility = DatabaseFilterUtilities()
+        field = test_utility._get_field(table, "name")
+
+        assert field == table.name
+
+    def test_invalid_get_field(self, flask_test_app_db):
+        table = get_entity_object_from_name("Investigation")
+
+        test_utility = DatabaseFilterUtilities()
+        with pytest.raises(FilterError):
+            test_utility._get_field(table, "unknown")

--- a/test/icat/test_query.py
+++ b/test/icat/test_query.py
@@ -345,66 +345,6 @@ class TestICATQuery:
 
         assert test_query.get_distinct_attributes() == ["summary", "name"]
 
-    @pytest.mark.parametrize(
-        "distinct_attrs, result, expected_output",
-        [
-            pytest.param(
-                ["summary"],
-                ["Summary 1"],
-                {"summary": "Summary 1"},
-                id="Single attribute",
-            ),
-            pytest.param(
-                ["startDate"],
-                (
-                    datetime(
-                        year=2020,
-                        month=1,
-                        day=4,
-                        hour=1,
-                        minute=1,
-                        second=1,
-                        tzinfo=timezone.utc,
-                    ),
-                ),
-                {"startDate": "2020-01-04 01:01:01+00:00"},
-                id="Single date attribute",
-            ),
-            pytest.param(
-                ["summary", "title"],
-                ("Summary 1", "Title 1"),
-                {"summary": "Summary 1", "title": "Title 1"},
-                id="Multiple attributes",
-            ),
-            pytest.param(
-                ["summary", "investigationUsers.role"],
-                ("Summary 1", "PI"),
-                {"summary": "Summary 1", "investigationUsers": {"role": "PI"}},
-                id="Multiple attributes with related attribute",
-            ),
-            pytest.param(
-                ["summary", "investigationUsers.investigation.name"],
-                ("Summary 1", "Investigation Name 1"),
-                {
-                    "summary": "Summary 1",
-                    "investigationUsers": {
-                        "investigation": {"name": "Investigation Name 1"},
-                    },
-                },
-                id="Multiple attributes with 2-level nested related attribute",
-            ),
-        ],
-    )
-    def test_valid_map_distinct_attributes_to_results(
-        self, icat_client, distinct_attrs, result, expected_output,
-    ):
-        test_query = ICATQuery(icat_client, "Investigation")
-        test_output = test_query.map_distinct_attributes_to_results(
-            distinct_attrs, result,
-        )
-
-        assert test_output == expected_output
-
     def test_include_fields_list_flatten(self, icat_client):
         included_field_set = {
             "investigationUsers.investigation.datasets",

--- a/test/icat/test_query.py
+++ b/test/icat/test_query.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from dateutil.tz import tzlocal
 from icat.entity import Entity
 import pytest
 

--- a/test/icat/test_query.py
+++ b/test/icat/test_query.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from icat.entity import Entity
 import pytest

--- a/test/test_map_distinct_attrs.py
+++ b/test/test_map_distinct_attrs.py
@@ -1,0 +1,63 @@
+from datagateway_api.common.helpers import map_distinct_attributes_to_results
+from datetime import datetime, timezone
+
+import pytest
+
+
+class TestMapDistinctAttrs:
+    @pytest.mark.parametrize(
+        "distinct_attrs, result, expected_output",
+        [
+            pytest.param(
+                ["summary"],
+                ["Summary 1"],
+                {"summary": "Summary 1"},
+                id="Single attribute",
+            ),
+            pytest.param(
+                ["startDate"],
+                (
+                    datetime(
+                        year=2020,
+                        month=1,
+                        day=4,
+                        hour=1,
+                        minute=1,
+                        second=1,
+                        tzinfo=timezone.utc,
+                    ),
+                ),
+                {"startDate": "2020-01-04 01:01:01+00:00"},
+                id="Single date attribute",
+            ),
+            pytest.param(
+                ["summary", "title"],
+                ("Summary 1", "Title 1"),
+                {"summary": "Summary 1", "title": "Title 1"},
+                id="Multiple attributes",
+            ),
+            pytest.param(
+                ["summary", "investigationUsers.role"],
+                ("Summary 1", "PI"),
+                {"summary": "Summary 1", "investigationUsers": {"role": "PI"}},
+                id="Multiple attributes with related attribute",
+            ),
+            pytest.param(
+                ["summary", "investigationUsers.investigation.name"],
+                ("Summary 1", "Investigation Name 1"),
+                {
+                    "summary": "Summary 1",
+                    "investigationUsers": {
+                        "investigation": {"name": "Investigation Name 1"},
+                    },
+                },
+                id="Multiple attributes with 2-level nested related attribute",
+            ),
+        ],
+    )
+    def test_valid_map_distinct_attributes_to_results(
+        self, distinct_attrs, result, expected_output,
+    ):
+        test_output = map_distinct_attributes_to_results(distinct_attrs, result)
+
+        assert test_output == expected_output

--- a/test/test_map_distinct_attrs.py
+++ b/test/test_map_distinct_attrs.py
@@ -1,7 +1,8 @@
-from datagateway_api.common.helpers import map_distinct_attributes_to_results
 from datetime import datetime, timezone
 
 import pytest
+
+from datagateway_api.common.helpers import map_distinct_attributes_to_results
 
 
 class TestMapDistinctAttrs:

--- a/test/test_map_distinct_attrs.py
+++ b/test/test_map_distinct_attrs.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
+from dateutil.tz import tzlocal
 import pytest
 
 from datagateway_api.common.helpers import map_distinct_attributes_to_results
@@ -25,7 +26,7 @@ class TestMapDistinctAttrs:
                         hour=1,
                         minute=1,
                         second=1,
-                        tzinfo=timezone.utc,
+                        tzinfo=tzlocal(),
                     ),
                 ),
                 {"startDate": "2020-01-04 01:01:01+00:00"},


### PR DESCRIPTION
This PR will close #223 

## Description
This branch allows related entities to be used on the distinct filter on the DB backend. The tests I've added in `test_get_with_filters.py` show the additional functionality this branch brings.

I've moved a lot of the functionality that was already present in `filters.py` into another class, `DatabaseFilterUtilities` - I've done this so both the where filter and distinct filter can make use of the same code. (1b7f1325c433cf0917bdbc8e557468a1f110296e contains the bulk of the class creation, 11f75a20a2dba6aac446fbaeb8d61a3f8a436233 removes most of the pre-existing, non-generic code). I've added a test class to test this class (bc9635153bae681e89962fb37d71c14cf16056e7).

I've separated out functionality of `add_query_join()`, more info in the commit message of a2538ccba6810fbd23c6f2c9d1d09ea89ba8498b

This morning, I properly fixed a bug I attempted to fix on Friday (proper fix at 9021fc865872586441fe710b29f7cfbd9ca87522). I tried to use a flag to limit when `add_query_join()` was called, but that didn't work in cases where there was related distinct fields and a where filter in the same request. f16cb15a4360e6fb818db8409508d6f9352127e0 shows actual cases that this bug fixes.


## Testing Instructions
I've added test cases to test/demonstrate the functionality added here. The main thing is that the functionality added here matches what's available in the ICAT backend so construct some GET requests with distinct fields (mixture of related and unrelated) and check they give the same results. You might find that some entity names need to be referenced differently in DB backend (e.g. `investigationType` which should be `type` according to the ICAT schema) but I'm aiming to fix those issues in #227.

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage
- [ ] Check the distinct functionality is the same in both backends

## Agile Board Tracking
Connect to #223