### PR TITLE
Fix complex include filters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,4 +11,5 @@ per-file-ignores =
   util/icat_db_generator.py: S311
   datagateway_api/wsgi.py:E402,F401
   datagateway_api/common/database/models.py: N815,A003
+  datagateway_api/common/icat/filters.py: C901
 enable-extensions=G

--- a/datagateway_api/common/icat/filters.py
+++ b/datagateway_api/common/icat/filters.py
@@ -246,7 +246,9 @@ class PythonICATIncludeFilter(IncludeFilter):
                             self._extract_filter_fields(".".join((key, element)))
                         elif isinstance(element, list):
                             for sub_element in element:
-                                self._extract_filter_fields(".".join(key, sub_element))
+                                self._extract_filter_fields(
+                                    ".".join((key, sub_element)),
+                                )
                         elif isinstance(element, dict):
                             for (
                                 inner_element_key,

--- a/datagateway_api/common/icat/filters.py
+++ b/datagateway_api/common/icat/filters.py
@@ -241,8 +241,29 @@ class PythonICATIncludeFilter(IncludeFilter):
                     self._extract_filter_fields(".".join((key, value)))
                 elif isinstance(value, list):
                     for element in value:
-                        # Will end up as: key.element1, key.element2, key.element3 etc.
-                        self._extract_filter_fields(".".join((key, element)))
+                        if isinstance(element, str):
+                            # Will end up as: key.element1, key.element2 etc.
+                            self._extract_filter_fields(".".join((key, element)))
+                        elif isinstance(element, list):
+                            for sub_element in element:
+                                self._extract_filter_fields(".".join(key, sub_element))
+                        elif isinstance(element, dict):
+                            for (
+                                inner_element_key,
+                                inner_element_value,
+                            ) in element.items():
+                                if not isinstance(inner_element_key, str):
+                                    raise FilterError(
+                                        "Include Filter: Dictionary key should only be"
+                                        " a string, not any other type",
+                                    )
+                                self._extract_filter_fields(
+                                    {
+                                        ".".join(
+                                            (key, inner_element_key),
+                                        ): inner_element_value,
+                                    },
+                                )
                 elif isinstance(value, dict):
                     for inner_key, inner_value in value.items():
                         if not isinstance(inner_key, str):

--- a/test/icat/filters/test_include_filter.py
+++ b/test/icat/filters/test_include_filter.py
@@ -45,7 +45,12 @@ class TestICATIncludeFilter:
                     "investigationUsers.user.userGroups",
                     "investigationUsers.investigation",
                 },
-                id="Complex use case used similarly in DataGateway",
+                id="complex use case used similarly in DataGateway",
+            ),
+            pytest.param(
+                {"investigationUsers": [["investigation.datasets"]]},
+                {"investigationUsers.investigation.datasets"},
+                id="dictionary with nested list value",
             ),
         ],
     )

--- a/test/icat/filters/test_include_filter.py
+++ b/test/icat/filters/test_include_filter.py
@@ -39,6 +39,14 @@ class TestICATIncludeFilter:
                 {"investigationUsers", "datasets", "facility"},
                 id="nested list",
             ),
+            pytest.param(
+                {"investigationUsers": [{"user": "userGroups"}, "investigation", []]},
+                {
+                    "investigationUsers.user.userGroups",
+                    "investigationUsers.investigation",
+                },
+                id="Complex use case used similarly in DataGateway",
+            ),
         ],
     )
     def test_valid_input(self, icat_query, filter_input, expected_output):
@@ -66,6 +74,10 @@ class TestICATIncludeFilter:
             pytest.param(
                 {"datasets": {"datafiles", "sample"}},
                 id="invalid inner dictionary value",
+            ),
+            pytest.param(
+                {"investigationUsers": [{2: "userGroups"}, "investigation"]},
+                id="Invalid inner key with nested dict and list",
             ),
         ],
     )


### PR DESCRIPTION
This PR will close #234 

## Description
As per the issue, a complex include filter input didn't work in the ICAT backend, but did work in the DB backend. This is a small change to fix that, with a couple of tests added to demonstrate this.

## Testing Instructions
Check the request in the issue (and ones similar to it) now work and don't return errors.

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile Board Tracking
Connect to #234 