### PR TITLE
Add CI Generator Script Comparison

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,9 @@ Add a set up instructions describing how the reviewer should test the code
 
 - [ ] Review code
 - [ ] Check GitHub Actions build
+- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a
+      deliberate change made to the script to change generated data (which isn't
+      actually a problem) or is there an underlying issue with the changes made?
 - [ ] Review changes to test coverage
 - [ ] {more steps here}
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -152,6 +152,7 @@ jobs:
 
   generator-script-testing:
     runs-on: ubuntu-16.04
+    continue-on-error: true
     name: icatdb Generator Script Consistency Test
     steps:
       - name: Add apt repo
@@ -262,6 +263,8 @@ jobs:
 
       # NOTE: If a delibrate change is made to the script that will change the data generated,
       # the diff (and therefore this job) will fail. If this is the case, don't be alarmed.
+      # The `continue-on-error` keyword has been added to this job so the workflow should
+      # pass when the PR is merged in, even if this job fails.
       # But, if you didn't mean to change the output of the script, there is likely a
       # problem with the changes made that will make the generator script's data
       # different to SciGateway preprod

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -248,6 +248,11 @@ jobs:
         with:
           ref: master
 
+      - name: Create config.json
+        run: cp datagateway_api/config.json.example datagateway_api/config.json
+      - name: Install dependencies
+        run: poetry install
+
       - name: Is API on master?
         run: pwd; git status
       - name: Add dummy data to icatdb

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -259,5 +259,11 @@ jobs:
         run: mysqldump -picatdbuserpw -uicatdbuser --skip-comments icatdb > ~/generator_script_dump_master.sql
 
       # Tests that the generator script produces the same data as is produced with master's version
+
+      # NOTE: If a delibrate change is made to the script that will change the data generated,
+      # the diff (and therefore this job) will fail. If this is the case, don't be alarmed.
+      # But, if you didn't mean to change the output of the script, there is likely a
+      # problem with the changes made that will make the generator script's data
+      # different to SciGateway preprod
       - name: Diff SQL dumps
         run: diff -s ~/generator_script_dump_master.sql ~/generator_script_dump_1.sql

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -229,5 +229,32 @@ jobs:
       - name: Get SQL dump of new dummy data
         run: mysqldump -picatdbuserpw -uicatdbuser --skip-comments icatdb > ~/generator_script_dump_2.sql
 
+      # Tests that the generator script produces consistent data over two separate runs
       - name: Diff SQL dumps
         run: diff -s ~/generator_script_dump_1.sql ~/generator_script_dump_2.sql
+
+
+      # Drop and re-create icatdb to remove generated data
+      - name: Drop icatdb
+        run: mysql -picatdbuserpw -uicatdbuser -e 'DROP DATABASE icatdb;'
+      - name: Create icatdb
+        run: mysql -picatdbuserpw -uicatdbuser -e 'CREATE DATABASE icatdb;'
+      # Regenerate table structure of icatdb
+      - name: Reinstall ICAT Server
+        run: cd /home/runner/install/icat.server; ./setup -vv install
+
+      - name: Checkout DataGateway API (master)
+        uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: Is API on master?
+        run: pwd; git status
+      - name: Add dummy data to icatdb
+        run: pwd; poetry run python -m util.icat_db_generator
+      - name: Get SQL dump of dummy data from master's generator script
+        run: mysqldump -picatdbuserpw -uicatdbuser --skip-comments icatdb > ~/generator_script_dump_master.sql
+
+      # Tests that the generator script produces the same data as is produced with master's version
+      - name: Diff SQL dumps
+        run: diff -s ~/generator_script_dump_master.sql ~/generator_script_dump_1.sql

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -253,10 +253,8 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: Is API on master?
-        run: pwd; git status
       - name: Add dummy data to icatdb
-        run: pwd; poetry run python -m util.icat_db_generator
+        run: poetry run python -m util.icat_db_generator
       - name: Get SQL dump of dummy data from master's generator script
         run: mysqldump -picatdbuserpw -uicatdbuser --skip-comments icatdb > ~/generator_script_dump_master.sql
 


### PR DESCRIPTION
This PR will close #246 

## Description
This is a small addition to the generator script CI job to compare generated data between master and the branch the CI is being run against. This will ensure that any future differences of the generator script are shown here rather than being hidden until we find them one day on preprod. 

As per the issue, I did think about storing the actual preprod dump on the repo (or maybe even the icatproject website?) but I decided against this due to the dump's size and I wanted to prevent any future schema changes causing differences between dumps (even if the data remains the same).

I've done a diff against the preprod dump and a dump of my local instance and they're the same, so we're starting from an 'identical base' to make this test actually meaningful. 

## Testing Instructions
I guess just check the CI steps make sense?

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] Review changes to test coverage

## Agile Board Tracking
Connect to #246 
