### PR TITLE
Use Ubuntu 20 on CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   tests:
-    runs-on: ubuntu-20.0
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: icatproject-contrib/icat-ansible
-        ref: change-payara-setup-script-url
+        ref: ubuntu-20-work
         path: icat-ansible
     - name: Install Ansible
       run: pip install -r icat-ansible/requirements.txt
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: change-payara-setup-script-url
+          ref: ubuntu-20-work
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   tests:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.0
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +91,7 @@ jobs:
       uses: codecov/codecov-action@v1
 
   linting:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     name: Linting
     steps:
     - name: Setup Python
@@ -111,7 +111,7 @@ jobs:
       run: nox -s lint
 
   formatting:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     name: Code Formatting
     steps:
     - name: Setup Python
@@ -131,7 +131,7 @@ jobs:
       run: nox -s black
 
   safety:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     name: Dependency Safety
     steps:
     - name: Setup Python
@@ -151,7 +151,7 @@ jobs:
       run: nox -s safety
 
   generator-script-testing:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     continue-on-error: true
     name: icatdb Generator Script Consistency Test
     steps:


### PR DESCRIPTION
This PR will close #239 

## Description
This is a small PR on DataGateway API's side to update the CI workflow to use Ubuntu 20.04 before 16.04 is dropped from GitHub Actions. The work in this involved changing ICAT Ansible so it became compatible with 20.04, as there were many instances when it broke using the new OS version. I have changed the branch of ICAT Ansible to use the one I've been working with and I know works on Ubuntu 20. Once the 'clean' changes for this solution have been pushed to master on ICAT Ansible, I will change the ICAT Ansible branch on the CI workflow back to master. 

## Testing Instructions
I guess the test is whether the CI passes or not.

- [x] Review code
- [x] Check GitHub Actions build
- [x] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a
      deliberate change made to the script to change generated data (which isn't
      actually a problem) or is there an underlying issue with the changes made?
- [x] Review changes to test coverage
- [ ] {more steps here}

## Agile Board Tracking
Connect to #239 
