### PR TITLE
Change ICAT Ansible back to master

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: icatproject-contrib/icat-ansible
-        ref: ubuntu-20-work
+        ref: master
         path: icat-ansible
     - name: Install Ansible
       run: pip install -r icat-ansible/requirements.txt
@@ -175,7 +175,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: icatproject-contrib/icat-ansible
-          ref: ubuntu-20-work
+          ref: master
           path: icat-ansible
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt


### PR DESCRIPTION
This PR will close #271

## Description
This closes #843. Just a simple branch reference change for ICAT Ansible. I've left the `ref: master` in because we seem to switch between branches of ICAT Ansible somewhat regularly so it just helps for next time if the `ref:` is left in place.

## Testing Instructions
No functionality changes, just make sure the CI passes.

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a
      deliberate change made to the script to change generated data (which isn't
      actually a problem) or is there an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile Board Tracking
Connect to #271 
