### PR TITLE
Fix Automated Releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.ADMIN_PAT }}
 
       - name: Python Semantic Release
         uses: relekang/python-semantic-release@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ADMIN_PAT }}


### PR DESCRIPTION
## Description
A small PR to fix #242 that was merged this morning. Since master branch is protected, Python Semantic Release cannot push using the default GITHUB_TOKEN. I've added an admin PAT with minimal scope (as [recommended](https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html) by the developers of the tool) as a solution to this.

## Testing Instructions
I've tested this on my fork with success. Once this is merged, a release for v1.0.0 should be made.

- [x] Review code
- [x] Check GitHub Actions build
- [x] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [x] Review changes to test coverage
- [x] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
