### PR TITLE
ci: specify Python 3.9.7 to fix issue found with 3.9.8

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.9.7'
         architecture: x64
     - name: Checkout DataGateway API
       uses: actions/checkout@v2
@@ -117,7 +117,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.9.7'
         architecture: x64
     - name: Checkout DataGateway API
       uses: actions/checkout@v2
@@ -137,7 +137,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.9.7'
         architecture: x64
     - name: Checkout DataGateway API
       uses: actions/checkout@v2
@@ -167,7 +167,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.9.7'
           architecture: x64
 
       # ICAT Ansible clone and install dependencies


### PR DESCRIPTION
## Description
I got the branch name wrong but this fixes the issue found with the CI with typed-ast on Python 3.9.8. Forcing the use of 3.9.7 should fix this.

No version bump as this only impacts the CI, zero code changes here.
## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [x] Review changes to test coverage
- [x] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
Connect to #{issue number}
