### PR TITLE
Add Study PIDs to Generator Script

### DIFF
--- a/datagateway_api/common/database/models.py
+++ b/datagateway_api/common/database/models.py
@@ -1229,6 +1229,7 @@ class STUDY(Base, EntityHelper, metaclass=EntityMeta):
     modId = Column("MOD_ID", String(255), nullable=False)
     modTime = Column("MOD_TIME", DateTime, nullable=False)
     name = Column("NAME", String(255), nullable=False)
+    pid = Column("PID", String(255))
     startDate = Column("STARTDATE", DateTime)
     status = Column("STATUS", Integer)
     userID = Column("USER_ID", ForeignKey("USER_.ID"), index=True)

--- a/datagateway_api/src/swagger/openapi.yaml
+++ b/datagateway_api/src/swagger/openapi.yaml
@@ -1659,6 +1659,8 @@ components:
           type: string
         name:
           type: string
+        pid:
+          type: string
         startDate:
           format: datetime
           type: string

--- a/util/icat_db_generator.py
+++ b/util/icat_db_generator.py
@@ -434,6 +434,7 @@ class StudyGenerator(Generator):
         apply_common_attributes(study, i)
         study.startDate = get_start_date(i)
         study.status = faker.random_int(0, 1)
+        study.pid = faker.isbn10(separator="-")
         study.userID = i
         post_entity(study)
 

--- a/util/icat_db_generator.py
+++ b/util/icat_db_generator.py
@@ -34,9 +34,6 @@ YEARS = args.years  # 4 Cycles per years generated
 faker = Faker()
 Faker.seed(SEED)
 
-pid_faker = Faker()
-pid_faker.seed_instance(SEED)
-
 
 engine = create_engine(
     config.get_config_value(APIConfigOptions.DB_URL),
@@ -426,6 +423,8 @@ class UserGroupGenerator(Generator):
 class StudyGenerator(Generator):
     tier = 3
     amount = UserGenerator.amount
+    pid_faker = Faker()
+    pid_faker.seed_instance(SEED)
 
     def generate(self):
         for i in range(1, self.amount):
@@ -437,7 +436,7 @@ class StudyGenerator(Generator):
         apply_common_attributes(study, i)
         study.startDate = get_start_date(i)
         study.status = faker.random_int(0, 1)
-        study.pid = pid_faker.isbn10(separator="-")
+        study.pid = StudyGenerator.pid_faker.isbn10(separator="-")
         study.userID = i
         post_entity(study)
 

--- a/util/icat_db_generator.py
+++ b/util/icat_db_generator.py
@@ -34,6 +34,9 @@ YEARS = args.years  # 4 Cycles per years generated
 faker = Faker()
 Faker.seed(SEED)
 
+pid_faker = Faker()
+pid_faker.seed_instance(SEED)
+
 
 engine = create_engine(
     config.get_config_value(APIConfigOptions.DB_URL),
@@ -434,7 +437,7 @@ class StudyGenerator(Generator):
         apply_common_attributes(study, i)
         study.startDate = get_start_date(i)
         study.status = faker.random_int(0, 1)
-        study.pid = faker.isbn10(separator="-")
+        study.pid = pid_faker.isbn10(separator="-")
         study.userID = i
         post_entity(study)
 


### PR DESCRIPTION
This PR will close #287 

## Description
These changes add PIDs to studies, in the same format as the script deals with `investigation.doi`.

Using the same instance of Faker that's used in the rest of the script would impact all the other data which is something we want to avoid. As a result, I've create a new instance of Faker and fed the input seed to that. I _think_ that's the best way to deal with this now and in the future?

Upon merging, the new version will be v1.0.1.

## Testing Instructions
Look for differences between the study data on SciGateway preprod and the data generated from this script. I have done this and the only differences are the additions of new DOIs, no other changes. I sent the following the request to preprod and my local instance and diffed them using a very nice online tool:
`http://{{datagateway-api}}/studies?order="id asc"&limit=10`

![image](https://user-images.githubusercontent.com/32678030/141446664-1db22df1-470a-4fe1-9d6d-cde94a6e3897.png)

The generator script job on the CI will fail but the only differences should be on the study data (only the PIDs).

- [x] Review code
- [x] Check GitHub Actions build
- [x] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [x] Review changes to test coverage
- [x] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

## Agile Board Tracking
Connect to #287 
