### PR TITLE
Extension Validation Bugfix

### DIFF
--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -27,10 +27,11 @@ def validate_extension(extension):
     """
     extension = extension.strip()
 
-    if not extension.startswith("/"):
-        raise ValueError("must start with '/'")
-    if extension.endswith("/"):
-        raise ValueError("must not end with '/'")
+    if extension:
+        if not extension.startswith("/"):
+            raise ValueError("must start with '/'")
+        if extension.endswith("/") and len(extension) != 1:
+            raise ValueError("must not end with '/'")
 
     return extension
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -133,7 +133,7 @@ class TestAPIConfig:
         [
             pytest.param("datagateway-api", id="DataGateway API with no leading slash"),
             pytest.param("search-api", id="Search API with no leading slash"),
-            pytest.param("my-extension/", id="Extension with trailing slash"),
+            pytest.param("/my-extension/", id="Extension with trailing slash"),
         ],
     )
     def test_invalid_extension_validation(self, input_extension):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,7 +3,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from datagateway_api.src.common.config import APIConfig
+from datagateway_api.src.common.config import APIConfig, validate_extension
 
 
 @pytest.fixture()
@@ -103,3 +103,39 @@ class TestAPIConfig:
         test_config.datagateway_api.set_backend_type("backend_name_changed")
 
         assert test_config.datagateway_api.backend == "backend_name_changed"
+
+    @pytest.mark.parametrize(
+        "input_extension, expected_extension",
+        [
+            pytest.param("/", "/", id="Slash"),
+            pytest.param("", "", id="Empty string, implied slash"),
+            pytest.param("/datagateway-api", "/datagateway-api", id="DataGateway API"),
+            pytest.param(
+                "   /datagateway-api   ",
+                "/datagateway-api",
+                id="DataGateway API with trailing and leading spaces",
+            ),
+            pytest.param("/search-api", "/search-api", id="Search API"),
+            pytest.param(
+                "   /search-api   ",
+                "/search-api",
+                id="Search API with trailing and leading spaces",
+            ),
+        ],
+    )
+    def test_valid_extension_validation(self, input_extension, expected_extension):
+        test_extension = validate_extension(input_extension)
+
+        assert test_extension == expected_extension
+
+    @pytest.mark.parametrize(
+        "input_extension",
+        [
+            pytest.param("datagateway-api", id="DataGateway API with no leading slash"),
+            pytest.param("search-api", id="Search API with no leading slash"),
+            pytest.param("my-extension/", id="Extension with trailing slash"),
+        ],
+    )
+    def test_invalid_extension_validation(self, input_extension):
+        with pytest.raises(ValueError):
+            validate_extension(input_extension)


### PR DESCRIPTION
## Description
This PR fixes a bug I found with `validate_extension()` when trying one of the APIs on `/`. I've also added some unit tests for this function so this can be avoided in the future.

## Testing Instructions

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

## Agile Board Tracking
