### PR TITLE
Search API Session/Client Handling

### DIFF
--- a/datagateway_api/config.json.example
+++ b/datagateway_api/config.json.example
@@ -12,9 +12,7 @@
     "search_api": {
         "extension": "/search-api",
         "icat_url": "https://localhost:8181",
-        "icat_check_cert": false,
-        "client_pool_init_size": 2,
-        "client_pool_max_size": 5
+        "icat_check_cert": false
     },
     "flask_reloader": false,
     "log_level": "WARN",

--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -126,8 +126,6 @@ class SearchAPI(BaseModel):
     validation of the SearchAPI config data using Python type annotations.
     """
 
-    client_pool_init_size: StrictInt
-    client_pool_max_size: StrictInt
     extension: StrictStr
     icat_check_cert: StrictBool
     icat_url: StrictStr
@@ -215,4 +213,7 @@ class APIConfig(BaseModel):
         return value
 
 
-config = APIConfig.load()
+class Config:
+    """Class containing config as a class variable so it can mocked during testing"""
+
+    config = APIConfig.load()

--- a/datagateway_api/src/common/logger_setup.py
+++ b/datagateway_api/src/common/logger_setup.py
@@ -1,9 +1,9 @@
 import logging.config
 from pathlib import Path
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
-LOG_FILE_NAME = Path(config.log_location)
+LOG_FILE_NAME = Path(Config.config.log_location)
 logger_config = {
     "version": 1,
     "formatters": {
@@ -14,7 +14,7 @@ logger_config = {
     },
     "handlers": {
         "default": {
-            "level": config.log_level,
+            "level": Config.config.log_level,
             "formatter": "default",
             "class": "logging.handlers.RotatingFileHandler",
             "filename": LOG_FILE_NAME,
@@ -22,7 +22,7 @@ logger_config = {
             "backupCount": 10,
         },
     },
-    "root": {"level": config.log_level, "handlers": ["default"]},
+    "root": {"level": Config.config.log_level, "handlers": ["default"]},
 }
 
 

--- a/datagateway_api/src/datagateway_api/icat/filters.py
+++ b/datagateway_api/src/datagateway_api/icat/filters.py
@@ -1,6 +1,6 @@
 import logging
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.exceptions import FilterError
 from datagateway_api.src.common.filters import (
     DistinctFieldFilter,
@@ -215,7 +215,8 @@ class PythonICATSkipFilter(SkipFilter):
 
     def apply_filter(self, query):
         icat_properties = get_icat_properties(
-            config.datagateway_api.icat_url, config.datagateway_api.icat_check_cert,
+            Config.config.datagateway_api.icat_url,
+            Config.config.datagateway_api.icat_check_cert,
         )
         icat_set_limit(query, self.skip_value, icat_properties["maxEntities"])
 

--- a/datagateway_api/src/datagateway_api/icat/icat_client_pool.py
+++ b/datagateway_api/src/datagateway_api/icat/icat_client_pool.py
@@ -3,7 +3,7 @@ import logging
 from icat.client import Client
 from object_pool import ObjectPool
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 log = logging.getLogger()
 
@@ -13,12 +13,12 @@ class ICATClient(Client):
 
     def __init__(self, client_use="datagateway_api"):
         if client_use == "datagateway_api":
-            icat_url = config.datagateway_api.icat_url
-            icat_check_cert = config.datagateway_api.icat_check_cert
+            icat_url = Config.config.datagateway_api.icat_url
+            icat_check_cert = Config.config.datagateway_api.icat_check_cert
         else:
             # Search API use cases
-            icat_url = config.search_api.icat_url
-            icat_check_cert = config.search_api.icat_check_cert
+            icat_url = Config.config.search_api.icat_url
+            icat_check_cert = Config.config.search_api.icat_check_cert
 
         super().__init__(icat_url, checkCert=icat_check_cert)
         # When clients are cleaned up, sessions won't be logged out
@@ -41,8 +41,8 @@ def create_client_pool():
 
     return ObjectPool(
         ICATClient,
-        min_init=config.datagateway_api.client_pool_init_size,
-        max_capacity=config.datagateway_api.client_pool_max_size,
+        min_init=Config.config.datagateway_api.client_pool_init_size,
+        max_capacity=Config.config.datagateway_api.client_pool_max_size,
         max_reusable=0,
         expires=0,
     )

--- a/datagateway_api/src/datagateway_api/icat/icat_client_pool.py
+++ b/datagateway_api/src/datagateway_api/icat/icat_client_pool.py
@@ -11,11 +11,16 @@ log = logging.getLogger()
 class ICATClient(Client):
     """Wrapper class to allow an object pool of client objects to be created"""
 
-    def __init__(self):
-        super().__init__(
-            config.datagateway_api.icat_url,
-            checkCert=config.datagateway_api.icat_check_cert,
-        )
+    def __init__(self, client_use="datagateway_api"):
+        if client_use == "datagateway_api":
+            icat_url = config.datagateway_api.icat_url
+            icat_check_cert = config.datagateway_api.icat_check_cert
+        else:
+            # Search API use cases
+            icat_url = config.search_api.icat_url
+            icat_check_cert = config.search_api.icat_check_cert
+
+        super().__init__(icat_url, checkCert=icat_check_cert)
         # When clients are cleaned up, sessions won't be logged out
         self.autoLogout = False
 

--- a/datagateway_api/src/datagateway_api/icat/lru_cache.py
+++ b/datagateway_api/src/datagateway_api/icat/lru_cache.py
@@ -2,7 +2,7 @@ import logging
 
 from cachetools.lru import LRUCache
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 log = logging.getLogger()
 
@@ -19,7 +19,7 @@ class ExtendedLRUCache(LRUCache):
     """
 
     def __init__(self):
-        super().__init__(maxsize=config.datagateway_api.client_cache_size)
+        super().__init__(maxsize=Config.config.datagateway_api.client_cache_size)
 
     def popitem(self):
         key, client = super().popitem()

--- a/datagateway_api/src/datagateway_api/query_filter_factory.py
+++ b/datagateway_api/src/datagateway_api/query_filter_factory.py
@@ -1,6 +1,6 @@
 import logging
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.exceptions import (
     ApiError,
     FilterError,
@@ -27,7 +27,7 @@ class QueryFilterFactory(object):
         :raises FilterError: If the filter name is not recognised
         """
 
-        backend_type = config.datagateway_api.backend
+        backend_type = Config.config.datagateway_api.backend
         if backend_type == "db":
             from datagateway_api.src.datagateway_api.database.filters import (
                 DatabaseDistinctFieldFilter as DistinctFieldFilter,

--- a/datagateway_api/src/main.py
+++ b/datagateway_api/src/main.py
@@ -8,7 +8,7 @@ from datagateway_api.src.api_start_utils import (
     create_openapi_endpoint,
     openapi_config,
 )
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.logger_setup import setup_logger
 
 setup_logger()
@@ -23,8 +23,8 @@ create_openapi_endpoint(app, spec)
 
 if __name__ == "__main__":
     app.run(
-        host=config.host,
-        port=config.port,
-        debug=config.debug_mode,
-        use_reloader=config.flask_reloader,
+        host=Config.config.host,
+        port=Config.config.port,
+        debug=Config.config.debug_mode,
+        use_reloader=Config.config.flask_reloader,
     )

--- a/datagateway_api/src/resources/search_api_endpoints.py
+++ b/datagateway_api/src/resources/search_api_endpoints.py
@@ -1,9 +1,14 @@
 from flask_restful import Resource
 
+from datagateway_api.src.search_api.helpers import (
+    get_count,
+    get_files,
+    get_files_count,
+    get_search,
+    get_with_id,
+)
 
-# TODO - Might need kwargs on get_search_endpoint(), get_single_endpoint(),
-# get_number_count_endpoint(), get_files_endpoint(), get_number_count_files_endpoint()
-# for client handling?
+
 def get_search_endpoint(name):
     """
     TODO - Add docstring
@@ -11,19 +16,7 @@ def get_search_endpoint(name):
 
     class Endpoint(Resource):
         def get(self):
-            """
-            TODO - Need to return similar to
-            return (
-                backend.get_with_filters(
-                    get_session_id_from_auth_header(),
-                    entity_type,
-                    get_filters_from_query_string(),
-                    **kwargs,
-                ),
-                200,
-            )
-            """
-            pass
+            return get_search(name), 200
 
         # TODO - Add `get.__doc__`
 
@@ -38,8 +31,7 @@ def get_single_endpoint(name):
 
     class EndpointWithID(Resource):
         def get(self, pid):
-            # TODO - Add return
-            pass
+            return get_with_id(name, pid), 200
 
         # TODO - Add `get.__doc__`
 
@@ -54,8 +46,7 @@ def get_number_count_endpoint(name):
 
     class CountEndpoint(Resource):
         def get(self):
-            # TODO - Add return
-            pass
+            return get_count(name), 200
 
         # TODO - Add `get.__doc__`
 
@@ -70,8 +61,7 @@ def get_files_endpoint(name):
 
     class FilesEndpoint(Resource):
         def get(self, pid):
-            # TODO - Add return
-            pass
+            return get_files(name), 200
 
         # TODO - Add `get.__doc__`
 
@@ -86,8 +76,7 @@ def get_number_count_files_endpoint(name):
 
     class CountFilesEndpoint(Resource):
         def get(self, pid):
-            # TODO - Add return
-            pass
+            return get_files_count(name, pid)
 
         # TODO - Add `get.__doc__`
 

--- a/datagateway_api/src/search_api/helpers.py
+++ b/datagateway_api/src/search_api/helpers.py
@@ -1,8 +1,8 @@
 import logging
 
 from datagateway_api.src.search_api.session_handler import (
-    SessionHandler,
     client_manager,
+    SessionHandler,
 )
 
 
@@ -19,7 +19,7 @@ def get_search(entity_name, filters=None):
 
 
 @client_manager
-def get_with_id(entity_name, id, filters=None):
+def get_with_id(entity_name, id_, filters=None):
     pass
 
 
@@ -34,5 +34,5 @@ def get_files(entity_name, filters=None):
 
 
 @client_manager
-def get_files_count(entity_name, id, filters=None):
+def get_files_count(entity_name, id_, filters=None):
     pass

--- a/datagateway_api/src/search_api/helpers.py
+++ b/datagateway_api/src/search_api/helpers.py
@@ -1,3 +1,42 @@
-"""
-Code to store helper functions to deal with the endpoints, like for DataGateway API
-"""
+import logging
+
+from datagateway_api.src.search_api.session_handler import (
+    SessionHandler,
+    client_manager,
+)
+
+
+log = logging.getLogger()
+
+
+# TODO - Make filters mandatory, if no filters are in a request an empty list will be
+# given to these functions
+@client_manager
+def get_search(entity_name, filters=None):
+    # TODO - Remove this debug logging when implementing the endpoints, this is just to
+    # show the client handling works
+    log.debug(
+        "Client: %s, Session ID: %s",
+        SessionHandler.client,
+        SessionHandler.client.sessionId,
+    )
+
+
+@client_manager
+def get_with_id(entity_name, id, filters=None):
+    pass
+
+
+@client_manager
+def get_count(entity_name, filters=None):
+    pass
+
+
+@client_manager
+def get_files(entity_name, filters=None):
+    pass
+
+
+@client_manager
+def get_files_count(entity_name, id, filters=None):
+    pass

--- a/datagateway_api/src/search_api/helpers.py
+++ b/datagateway_api/src/search_api/helpers.py
@@ -13,13 +13,9 @@ log = logging.getLogger()
 # given to these functions
 @client_manager
 def get_search(entity_name, filters=None):
-    # TODO - Remove this debug logging when implementing the endpoints, this is just to
-    # show the client handling works
-    log.debug(
-        "Client: %s, Session ID: %s",
-        SessionHandler.client,
-        SessionHandler.client.sessionId,
-    )
+    # TODO - `getApiVersion()` used as a placeholder for testing client handling
+    # Replace with endpoint functionality when implementing the endpoints
+    return SessionHandler.client.getApiVersion()
 
 
 @client_manager

--- a/datagateway_api/src/search_api/session_handler.py
+++ b/datagateway_api/src/search_api/session_handler.py
@@ -32,7 +32,7 @@ def client_manager(method):
         try:
             SessionHandler.client.getRemainingMinutes()
         except ICATSessionError as e:
-            log.debug("Current client session expired: %s", e)
+            log.debug("Current client session expired: %s", e.args)
             SessionHandler.client.login("anon", {})
 
         return method(*args, **kwargs)

--- a/datagateway_api/src/search_api/session_handler.py
+++ b/datagateway_api/src/search_api/session_handler.py
@@ -15,7 +15,7 @@ class SessionHandler:
     anon user
     """
 
-    client = ICATClient()
+    client = ICATClient(client_use="search_api")
 
 
 def client_manager(method):

--- a/test/datagateway_api/db/conftest.py
+++ b/test/datagateway_api/db/conftest.py
@@ -3,7 +3,7 @@ import uuid
 
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.constants import Constants
 from datagateway_api.src.datagateway_api.database.helpers import (
     delete_row_by_id,
@@ -117,7 +117,8 @@ def isis_specific_endpoint_data_db():
 @pytest.fixture()
 def final_instrument_id(flask_test_app_db, valid_db_credentials_header):
     final_instrument_result = flask_test_app_db.get(
-        f'{config.datagateway_api.extension}/instruments/findone?order="id DESC"',
+        f"{Config.config.datagateway_api.extension}/instruments/findone"
+        '?order="id DESC"',
         headers=valid_db_credentials_header,
     )
     return final_instrument_result.json["id"]
@@ -126,7 +127,8 @@ def final_instrument_id(flask_test_app_db, valid_db_credentials_header):
 @pytest.fixture()
 def final_facilitycycle_id(flask_test_app_db, valid_db_credentials_header):
     final_facilitycycle_result = flask_test_app_db.get(
-        f'{config.datagateway_api.extension}/facilitycycles/findone?order="id DESC"',
+        f"{Config.config.datagateway_api.extension}/facilitycycles/findone"
+        '?order="id DESC"',
         headers=valid_db_credentials_header,
     )
     return final_facilitycycle_result.json["id"]

--- a/test/datagateway_api/db/endpoints/test_count_with_filters_db.py
+++ b/test/datagateway_api/db/endpoints/test_count_with_filters_db.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 class TestDBCountWithFilters:
@@ -9,7 +9,7 @@ class TestDBCountWithFilters:
         self, flask_test_app_db, valid_db_credentials_header,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations/count?where="
+            f"{Config.config.datagateway_api.extension}/investigations/count?where="
             '{"title": {"like": "Title for DataGateway API Testing (DB)"}}',
             headers=valid_db_credentials_header,
         )
@@ -20,7 +20,7 @@ class TestDBCountWithFilters:
         self, flask_test_app_db, valid_db_credentials_header,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations/count?where="
+            f"{Config.config.datagateway_api.extension}/investigations/count?where="
             '{"title": {"like": "This filter should cause a404 for testing '
             'purposes..."}}',
             headers=valid_db_credentials_header,

--- a/test/datagateway_api/db/endpoints/test_findone_db.py
+++ b/test/datagateway_api/db/endpoints/test_findone_db.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 class TestDBFindone:
@@ -9,7 +9,7 @@ class TestDBFindone:
         single_investigation_test_data_db,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations/findone?where="
+            f"{Config.config.datagateway_api.extension}/investigations/findone?where="
             '{"title": {"like": "Title for DataGateway API Testing (DB)"}}',
             headers=valid_db_credentials_header,
         )
@@ -20,7 +20,7 @@ class TestDBFindone:
         self, flask_test_app_db, valid_db_credentials_header,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations/findone?where="
+            f"{Config.config.datagateway_api.extension}/investigations/findone?where="
             '{"title": {"eq": "This filter should cause a404 for testing '
             'purposes..."}}',
             headers=valid_db_credentials_header,

--- a/test/datagateway_api/db/endpoints/test_get_by_id_db.py
+++ b/test/datagateway_api/db/endpoints/test_get_by_id_db.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 class TestDBGetByID:
@@ -10,14 +10,14 @@ class TestDBGetByID:
     ):
         # Need to identify the ID given to the test data
         investigation_data = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Title for DataGateway API Testing (DB)"}}',
             headers=valid_db_credentials_header,
         )
         test_data_id = investigation_data.json[0]["id"]
 
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations/{test_data_id}",
+            f"{Config.config.datagateway_api.extension}/investigations/{test_data_id}",
             headers=valid_db_credentials_header,
         )
 
@@ -27,7 +27,7 @@ class TestDBGetByID:
         self, flask_test_app_db, valid_db_credentials_header,
     ):
         final_investigation_result = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations/findone?order="
+            f"{Config.config.datagateway_api.extension}/investigations/findone?order="
             '"id DESC"',
             headers=valid_db_credentials_header,
         )
@@ -35,7 +35,8 @@ class TestDBGetByID:
 
         # Adding 100 onto the ID to the most recent result should ensure a 404
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations/{test_data_id + 100}",
+            f"{Config.config.datagateway_api.extension}/investigations"
+            f"/{test_data_id + 100}",
             headers=valid_db_credentials_header,
         )
 

--- a/test/datagateway_api/db/endpoints/test_get_with_filters.py
+++ b/test/datagateway_api/db/endpoints/test_get_with_filters.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.constants import Constants
 from datagateway_api.src.common.date_handler import DateHandler
 
@@ -13,7 +13,7 @@ class TestDBGetWithFilters:
         single_investigation_test_data_db,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Title for DataGateway API Testing (DB)"}}',
             headers=valid_db_credentials_header,
         )
@@ -24,7 +24,7 @@ class TestDBGetWithFilters:
         self, flask_test_app_db, valid_db_credentials_header,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"eq": "This filter should cause a 404 fortesting '
             'purposes..."}}',
             headers=valid_db_credentials_header,
@@ -37,7 +37,7 @@ class TestDBGetWithFilters:
         self, flask_test_app_db, valid_db_credentials_header,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Title for DataGateway API Testing (DB)"}}'
             '&distinct="title"',
             headers=valid_db_credentials_header,
@@ -128,7 +128,7 @@ class TestDBGetWithFilters:
         expected_response,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Title for DataGateway API Testing (DB)"}}'
             f"&distinct={distinct_param}",
             headers=valid_db_credentials_header,
@@ -148,7 +148,7 @@ class TestDBGetWithFilters:
         limit_value = 2
 
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Title for DataGateway API Testing (DB)"}}'
             f'&skip={skip_value}&limit={limit_value}&order="id ASC"',
             headers=valid_db_credentials_header,

--- a/test/datagateway_api/db/endpoints/test_ping_db.py
+++ b/test/datagateway_api/db/endpoints/test_ping_db.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.constants import Constants
 from datagateway_api.src.common.exceptions import DatabaseError
 from datagateway_api.src.datagateway_api.backends import create_backend
@@ -12,7 +12,7 @@ from datagateway_api.src.datagateway_api.backends import create_backend
 class TestICATPing:
     def test_valid_ping(self, flask_test_app_db):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/ping",
+            f"{Config.config.datagateway_api.extension}/ping",
         )
 
         assert test_response.json == Constants.PING_OK_RESPONSE

--- a/test/datagateway_api/db/endpoints/test_table_endpoints_db.py
+++ b/test/datagateway_api/db/endpoints/test_table_endpoints_db.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 class TestDBTableEndpoints:
@@ -14,7 +14,7 @@ class TestDBTableEndpoints:
         isis_specific_endpoint_data_db,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{int(isis_specific_endpoint_data_db[0])}/facilitycycles",
             headers=valid_db_credentials_header,
         )
@@ -25,7 +25,7 @@ class TestDBTableEndpoints:
         self, flask_test_app_db, valid_db_credentials_header, final_instrument_id,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles",
             headers=valid_db_credentials_header,
         )
@@ -39,7 +39,7 @@ class TestDBTableEndpoints:
         isis_specific_endpoint_data_db,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{isis_specific_endpoint_data_db[0]}/facilitycycles/count",
             headers=valid_db_credentials_header,
         )
@@ -50,7 +50,7 @@ class TestDBTableEndpoints:
         self, flask_test_app_db, valid_db_credentials_header, final_instrument_id,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles/count",
             headers=valid_db_credentials_header,
         )
@@ -64,7 +64,7 @@ class TestDBTableEndpoints:
         isis_specific_endpoint_data_db,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{isis_specific_endpoint_data_db[0]}/facilitycycles"
             f"/{isis_specific_endpoint_data_db[1].to_dict()['id']}/investigations",
             headers=valid_db_credentials_header,
@@ -80,7 +80,7 @@ class TestDBTableEndpoints:
         final_facilitycycle_id,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles"
             f"/{final_facilitycycle_id + 100}/investigations",
             headers=valid_db_credentials_header,
@@ -95,7 +95,7 @@ class TestDBTableEndpoints:
         isis_specific_endpoint_data_db,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{isis_specific_endpoint_data_db[0]}/facilitycycles"
             f"/{isis_specific_endpoint_data_db[1].to_dict()['id']}"
             "/investigations/count",
@@ -112,7 +112,7 @@ class TestDBTableEndpoints:
         final_facilitycycle_id,
     ):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles"
             f"/{final_facilitycycle_id + 100}/investigations/count",
             headers=valid_db_credentials_header,

--- a/test/datagateway_api/db/test_requires_session_id.py
+++ b/test/datagateway_api/db/test_requires_session_id.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 class TestRequiresSessionID:
@@ -9,14 +9,14 @@ class TestRequiresSessionID:
 
     def test_invalid_missing_credentials(self, flask_test_app_db):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/datafiles",
+            f"{Config.config.datagateway_api.extension}/datafiles",
         )
 
         assert test_response.status_code == 401
 
     def test_invalid_credentials(self, flask_test_app_db, invalid_credentials_header):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/datafiles",
+            f"{Config.config.datagateway_api.extension}/datafiles",
             headers=invalid_credentials_header,
         )
 
@@ -24,7 +24,7 @@ class TestRequiresSessionID:
 
     def test_bad_credentials(self, flask_test_app_db, bad_credentials_header):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/datafiles",
+            f"{Config.config.datagateway_api.extension}/datafiles",
             headers=bad_credentials_header,
         )
 
@@ -32,7 +32,7 @@ class TestRequiresSessionID:
 
     def test_valid_credentials(self, flask_test_app_db, valid_db_credentials_header):
         test_response = flask_test_app_db.get(
-            f"{config.datagateway_api.extension}/datafiles?limit=0",
+            f"{Config.config.datagateway_api.extension}/datafiles?limit=0",
             headers=valid_db_credentials_header,
         )
 

--- a/test/datagateway_api/icat/conftest.py
+++ b/test/datagateway_api/icat/conftest.py
@@ -12,7 +12,7 @@ from datagateway_api.src.api_start_utils import (
     create_api_endpoints,
     create_app_infrastructure,
 )
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.endpoints.test_create_icat import TestICATCreateData
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
@@ -20,11 +20,11 @@ from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 @pytest.fixture(scope="package")
 def icat_client():
     client = Client(
-        config.datagateway_api.icat_url,
-        checkCert=config.datagateway_api.icat_check_cert,
+        Config.config.datagateway_api.icat_url,
+        checkCert=Config.config.datagateway_api.icat_check_cert,
     )
     client.login(
-        config.test_mechanism, config.test_user_credentials.dict(),
+        Config.config.test_mechanism, Config.config.test_user_credentials.dict(),
     )
     return client
 
@@ -149,7 +149,8 @@ def isis_specific_endpoint_data(icat_client):
 @pytest.fixture()
 def final_instrument_id(flask_test_app_icat, valid_icat_credentials_header):
     final_instrument_result = flask_test_app_icat.get(
-        f'{config.datagateway_api.extension}/instruments/findone?order="id DESC"',
+        f"{Config.config.datagateway_api.extension}/instruments/findone"
+        '?order="id DESC"',
         headers=valid_icat_credentials_header,
     )
     return final_instrument_result.json["id"]
@@ -158,7 +159,8 @@ def final_instrument_id(flask_test_app_icat, valid_icat_credentials_header):
 @pytest.fixture()
 def final_facilitycycle_id(flask_test_app_icat, valid_icat_credentials_header):
     final_facilitycycle_result = flask_test_app_icat.get(
-        f'{config.datagateway_api.extension}/facilitycycles/findone?order="id DESC"',
+        f"{Config.config.datagateway_api.extension}/facilitycycles/findone"
+        '?order="id DESC"',
         headers=valid_icat_credentials_header,
     )
     return final_facilitycycle_result.json["id"]
@@ -181,7 +183,7 @@ def remove_test_created_investigation_data(
     yield
 
     created_test_data = flask_test_app_icat.get(
-        f"{config.datagateway_api.extension}/investigations?where="
+        f"{Config.config.datagateway_api.extension}/investigations?where="
         '{"name":{"like":'
         f'"{TestICATCreateData.investigation_name_prefix}"'
         "}}",
@@ -194,6 +196,7 @@ def remove_test_created_investigation_data(
 
     for investigation_id in investigation_ids:
         flask_test_app_icat.delete(
-            f"{config.datagateway_api.extension}/investigations/{investigation_id}",
+            f"{Config.config.datagateway_api.extension}/investigations"
+            f"/{investigation_id}",
             headers=valid_icat_credentials_header,
         )

--- a/test/datagateway_api/icat/endpoints/test_count_with_filters_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_count_with_filters_icat.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 class TestICATCountWithFilters:
@@ -30,7 +30,8 @@ class TestICATCountWithFilters:
         expected_result,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations/count{query_params}",
+            f"{Config.config.datagateway_api.extension}/investigations"
+            f"/count{query_params}",
             headers=valid_icat_credentials_header,
         )
 
@@ -40,7 +41,7 @@ class TestICATCountWithFilters:
         self, flask_test_app_icat, valid_icat_credentials_header,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations/count?where="
+            f"{Config.config.datagateway_api.extension}/investigations/count?where="
             '{"title": {"like": "This filter should cause 0results to be found '
             'for testing purposes..."}}',
             headers=valid_icat_credentials_header,

--- a/test/datagateway_api/icat/endpoints/test_create_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_create_icat.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
 
@@ -28,7 +28,7 @@ class TestICATCreateData:
         ]
 
         test_response = flask_test_app_icat.post(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=create_investigations_json,
         )
@@ -63,7 +63,7 @@ class TestICATCreateData:
         }
 
         test_response = flask_test_app_icat.post(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=create_investigation_json,
         )
@@ -87,7 +87,7 @@ class TestICATCreateData:
         }
 
         test_response = flask_test_app_icat.post(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=invalid_request_body,
         )
@@ -113,7 +113,7 @@ class TestICATCreateData:
         }
 
         test_response = flask_test_app_icat.post(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=existing_object_json,
         )
@@ -142,13 +142,13 @@ class TestICATCreateData:
         ]
 
         create_response = flask_test_app_icat.post(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=request_body,
         )
 
         get_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"eq": "'
             f'{request_body[0]["title"]}'
             '"}}',

--- a/test/datagateway_api/icat/endpoints/test_delete_by_id_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_delete_by_id_icat.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 class TestDeleteByID:
@@ -9,7 +9,7 @@ class TestDeleteByID:
         single_investigation_test_data,
     ):
         test_response = flask_test_app_icat.delete(
-            f"{config.datagateway_api.extension}/investigations"
+            f"{Config.config.datagateway_api.extension}/investigations"
             f'/{single_investigation_test_data[0]["id"]}',
             headers=valid_icat_credentials_header,
         )
@@ -22,7 +22,7 @@ class TestDeleteByID:
         """Request with a non-existent ID"""
 
         final_investigation_result = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations"
+            f"{Config.config.datagateway_api.extension}/investigations"
             '/findone?order="id DESC"',
             headers=valid_icat_credentials_header,
         )
@@ -30,7 +30,8 @@ class TestDeleteByID:
 
         # Adding 100 onto the ID to the most recent result should ensure a 404
         test_response = flask_test_app_icat.delete(
-            f"{config.datagateway_api.extension}/investigations/{test_data_id + 100}",
+            f"{Config.config.datagateway_api.extension}/investigations"
+            f"/{test_data_id + 100}",
             headers=valid_icat_credentials_header,
         )
 

--- a/test/datagateway_api/icat/endpoints/test_findone_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_findone_icat.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
 
@@ -10,7 +10,7 @@ class TestICATFindone:
         single_investigation_test_data,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations/findone?where="
+            f"{Config.config.datagateway_api.extension}/investigations/findone?where="
             '{"title": {"like": "Test data for the Python ICAT Backend on '
             'DataGateway API"}}',
             headers=valid_icat_credentials_header,
@@ -23,7 +23,7 @@ class TestICATFindone:
         self, flask_test_app_icat, valid_icat_credentials_header,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations/findone?where="
+            f"{Config.config.datagateway_api.extension}/investigations/findone?where="
             '{"title": {"eq": "This filter should cause a404 for testing '
             'purposes..."}}',
             headers=valid_icat_credentials_header,

--- a/test/datagateway_api/icat/endpoints/test_get_by_id_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_get_by_id_icat.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
 
@@ -11,7 +11,7 @@ class TestICATGetByID:
     ):
         # Need to identify the ID given to the test data
         investigation_data = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Test data for the Python ICAT Backend on '
             'DataGateway API"}}',
             headers=valid_icat_credentials_header,
@@ -19,7 +19,7 @@ class TestICATGetByID:
         test_data_id = investigation_data.json[0]["id"]
 
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations/{test_data_id}",
+            f"{Config.config.datagateway_api.extension}/investigations/{test_data_id}",
             headers=valid_icat_credentials_header,
         )
         # Get with ID gives a dictionary response (only ever one result from that kind
@@ -34,7 +34,7 @@ class TestICATGetByID:
         """Request with a non-existent ID"""
 
         final_investigation_result = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations/findone?order="
+            f"{Config.config.datagateway_api.extension}/investigations/findone?order="
             '"id DESC"',
             headers=valid_icat_credentials_header,
         )
@@ -42,7 +42,8 @@ class TestICATGetByID:
 
         # Adding 100 onto the ID to the most recent result should ensure a 404
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations/{test_data_id + 100}",
+            f"{Config.config.datagateway_api.extension}/investigations"
+            f"/{test_data_id + 100}",
             headers=valid_icat_credentials_header,
         )
 

--- a/test/datagateway_api/icat/endpoints/test_get_with_filters_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_get_with_filters_icat.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
 
@@ -12,7 +12,7 @@ class TestICATGetWithFilters:
         single_investigation_test_data,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Test data for the Python ICAT Backend on '
             'DataGateway API"}}',
             headers=valid_icat_credentials_header,
@@ -25,7 +25,7 @@ class TestICATGetWithFilters:
         self, flask_test_app_icat, valid_icat_credentials_header,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"eq": "This filter should cause a 404 fortesting '
             'purposes..."}}',
             headers=valid_icat_credentials_header,
@@ -38,7 +38,7 @@ class TestICATGetWithFilters:
         self, flask_test_app_icat, valid_icat_credentials_header,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Test data for the Python ICAT Backend on '
             'DataGateway API"}}&distinct="title"',
             headers=valid_icat_credentials_header,
@@ -62,7 +62,7 @@ class TestICATGetWithFilters:
         limit_value = 2
 
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations?where="
+            f"{Config.config.datagateway_api.extension}/investigations?where="
             '{"title": {"like": "Test data for the Python ICAT Backend on '
             'DataGateway API"}}'
             f'&skip={skip_value}&limit={limit_value}&order="id ASC"',

--- a/test/datagateway_api/icat/endpoints/test_ping_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_ping_icat.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from icat.exception import ICATError
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.constants import Constants
 from datagateway_api.src.common.exceptions import PythonICATError
 from datagateway_api.src.datagateway_api.backends import create_backend
@@ -13,7 +13,7 @@ from datagateway_api.src.datagateway_api.icat.icat_client_pool import create_cli
 class TestICATPing:
     def test_valid_ping(self, flask_test_app_icat):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/ping",
+            f"{Config.config.datagateway_api.extension}/ping",
         )
 
         assert test_response.json == Constants.PING_OK_RESPONSE

--- a/test/datagateway_api/icat/endpoints/test_table_endpoints_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_table_endpoints_icat.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
 
@@ -15,7 +15,7 @@ class TestICATableEndpoints:
         isis_specific_endpoint_data,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{isis_specific_endpoint_data[0]}/facilitycycles",
             headers=valid_icat_credentials_header,
         )
@@ -28,7 +28,7 @@ class TestICATableEndpoints:
         self, flask_test_app_icat, valid_icat_credentials_header, final_instrument_id,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles",
             headers=valid_icat_credentials_header,
         )
@@ -42,7 +42,7 @@ class TestICATableEndpoints:
         isis_specific_endpoint_data,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{isis_specific_endpoint_data[0]}/facilitycycles/count",
             headers=valid_icat_credentials_header,
         )
@@ -53,7 +53,7 @@ class TestICATableEndpoints:
         self, flask_test_app_icat, valid_icat_credentials_header, final_instrument_id,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles/count",
             headers=valid_icat_credentials_header,
         )
@@ -67,7 +67,7 @@ class TestICATableEndpoints:
         isis_specific_endpoint_data,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{isis_specific_endpoint_data[0]}/facilitycycles"
             f"/{isis_specific_endpoint_data[2]}/investigations",
             headers=valid_icat_credentials_header,
@@ -85,7 +85,7 @@ class TestICATableEndpoints:
         final_facilitycycle_id,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles"
             f"/{final_facilitycycle_id + 100}/investigations",
             headers=valid_icat_credentials_header,
@@ -100,7 +100,7 @@ class TestICATableEndpoints:
         isis_specific_endpoint_data,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{isis_specific_endpoint_data[0]}/facilitycycles"
             f"/{isis_specific_endpoint_data[2]}/investigations/count",
             headers=valid_icat_credentials_header,
@@ -116,7 +116,7 @@ class TestICATableEndpoints:
         final_facilitycycle_id,
     ):
         test_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/instruments"
+            f"{Config.config.datagateway_api.extension}/instruments"
             f"/{final_instrument_id + 100}/facilitycycles"
             f"/{final_facilitycycle_id + 100}/investigations/count",
             headers=valid_icat_credentials_header,

--- a/test/datagateway_api/icat/endpoints/test_update_by_id_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_update_by_id_icat.py
@@ -1,4 +1,4 @@
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
 
@@ -17,7 +17,7 @@ class TestUpdateByID:
         single_investigation_test_data[0].update(update_data_json)
 
         test_response = flask_test_app_icat.patch(
-            f"{config.datagateway_api.extension}/investigations"
+            f"{Config.config.datagateway_api.extension}/investigations"
             f"/{single_investigation_test_data[0]['id']}",
             headers=valid_icat_credentials_header,
             json=update_data_json,
@@ -40,7 +40,7 @@ class TestUpdateByID:
         }
 
         test_response = flask_test_app_icat.patch(
-            f"{config.datagateway_api.extension}/investigations"
+            f"{Config.config.datagateway_api.extension}/investigations"
             f"/{single_investigation_test_data[0]['id']}",
             headers=valid_icat_credentials_header,
             json=invalid_update_json,

--- a/test/datagateway_api/icat/endpoints/test_update_multiple_icat.py
+++ b/test/datagateway_api/icat/endpoints/test_update_multiple_icat.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from test.datagateway_api.icat.test_query import prepare_icat_data_for_assertion
 
 
@@ -28,7 +28,7 @@ class TestUpdateMultipleEntities:
             update_data_list.append(update_entity)
 
         test_response = flask_test_app_icat.patch(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=update_data_list,
         )
@@ -56,7 +56,7 @@ class TestUpdateMultipleEntities:
         single_investigation_test_data[0]["summary"] = expected_summary
 
         test_response = flask_test_app_icat.patch(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=update_data_json,
         )
@@ -78,7 +78,7 @@ class TestUpdateMultipleEntities:
         }
 
         test_response = flask_test_app_icat.patch(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=update_data_json,
         )
@@ -106,7 +106,7 @@ class TestUpdateMultipleEntities:
         }
 
         test_response = flask_test_app_icat.patch(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=invalid_update_data_json,
         )
@@ -138,7 +138,7 @@ class TestUpdateMultipleEntities:
         ]
 
         update_response = flask_test_app_icat.patch(
-            f"{config.datagateway_api.extension}/investigations",
+            f"{Config.config.datagateway_api.extension}/investigations",
             headers=valid_icat_credentials_header,
             json=request_body,
         )
@@ -147,7 +147,7 @@ class TestUpdateMultipleEntities:
         # were rolled back when the ICATValidationError occurred for the second entity
         # in the request body
         get_response = flask_test_app_icat.get(
-            f"{config.datagateway_api.extension}/investigations"
+            f"{Config.config.datagateway_api.extension}/investigations"
             f"/{multiple_investigation_test_data[0]['id']}",
             headers=valid_icat_credentials_header,
         )

--- a/test/datagateway_api/icat/filters/test_skip_filter.py
+++ b/test/datagateway_api/icat/filters/test_skip_filter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.exceptions import FilterError
 from datagateway_api.src.common.helpers import get_icat_properties
 from datagateway_api.src.datagateway_api.icat.filters import PythonICATSkipFilter
@@ -17,7 +17,8 @@ class TestICATSkipFilter:
         assert icat_query.limit == (
             skip_value,
             get_icat_properties(
-                config.datagateway_api.icat_url, config.datagateway_api.icat_check_cert,
+                Config.config.datagateway_api.icat_url,
+                Config.config.datagateway_api.icat_check_cert,
             )["maxEntities"],
         )
 

--- a/test/datagateway_api/icat/test_icat_client.py
+++ b/test/datagateway_api/icat/test_icat_client.py
@@ -1,10 +1,8 @@
-import json
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 from icat.client import Client
 import pytest
 
-from datagateway_api.src.common.config import APIConfig
 from datagateway_api.src.datagateway_api.icat.icat_client_pool import ICATClient
 
 

--- a/test/datagateway_api/icat/test_icat_client.py
+++ b/test/datagateway_api/icat/test_icat_client.py
@@ -1,5 +1,10 @@
-from icat.client import Client
+import json
+from unittest.mock import mock_open, patch
 
+from icat.client import Client
+import pytest
+
+from datagateway_api.src.common.config import APIConfig
 from datagateway_api.src.datagateway_api.icat.icat_client_pool import ICATClient
 
 
@@ -9,6 +14,47 @@ class TestICATClient:
         assert isinstance(test_icat_client, Client)
 
         assert not test_icat_client.autoLogout
+
+    @pytest.mark.parametrize(
+        "client_use, expected_url, expected_check_cert",
+        [
+            pytest.param(
+                "datagateway_api",
+                "https://localhost:8181/ICATService/ICAT?wsdl",
+                False,
+                id="DataGateway API Usage",
+            ),
+            pytest.param(
+                "search_api",
+                "https://localhost.testdomain:8181/ICATService/ICAT?wsdl",
+                True,
+                id="Search API Usage",
+            ),
+        ],
+    )
+    def test_client_use(
+        self, test_config_data, client_use, expected_url, expected_check_cert,
+    ):
+        with patch("builtins.open", mock_open(read_data=json.dumps(test_config_data))):
+            api_config = APIConfig.load("test/path")
+
+            class MockClient:
+                def __init__(url, checkCert=True):  # noqa
+                    print(f"URL: {url}, Cert: {checkCert}")
+                    # Would've preferred to assign these values to self but this didn't
+                    # seem to be possible
+                    Client.url = f"{url}/ICATService/ICAT?wsdl"
+                    Client.checkCert = checkCert
+
+            with patch(
+                "datagateway_api.src.common.config.Config.config", api_config,
+            ):
+                with patch(
+                    "icat.client.Client.__init__", side_effect=MockClient.__init__,
+                ):
+                    test_icat_client = ICATClient(client_use)
+                    assert test_icat_client.url == expected_url
+                    assert test_icat_client.checkCert == expected_check_cert
 
     def test_clean_up(self):
         test_icat_client = ICATClient()

--- a/test/datagateway_api/icat/test_icat_client.py
+++ b/test/datagateway_api/icat/test_icat_client.py
@@ -35,7 +35,6 @@ class TestICATClient:
     ):
         class MockClient:
             def __init__(url, checkCert=True):  # noqa
-                print(f"URL: {url}, Cert: {checkCert}")
                 # Would've preferred to assign these values to self but this didn't
                 # seem to be possible
                 Client.url = f"{url}/ICATService/ICAT?wsdl"

--- a/test/datagateway_api/icat/test_lru_cache.py
+++ b/test/datagateway_api/icat/test_lru_cache.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from cachetools import cached
 from icat.client import Client
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.datagateway_api.icat.icat_client_pool import create_client_pool
 from datagateway_api.src.datagateway_api.icat.lru_cache import ExtendedLRUCache
 
@@ -11,14 +11,14 @@ from datagateway_api.src.datagateway_api.icat.lru_cache import ExtendedLRUCache
 class TestLRUCache:
     def test_valid_cache_creation(self):
         test_cache = ExtendedLRUCache()
-        assert test_cache.maxsize == config.datagateway_api.client_cache_size
+        assert test_cache.maxsize == Config.config.datagateway_api.client_cache_size
 
     def test_valid_popitem(self):
         test_cache = ExtendedLRUCache()
         test_pool = create_client_pool()
         test_client = Client(
-            config.datagateway_api.icat_url,
-            checkCert=config.datagateway_api.icat_check_cert,
+            Config.config.datagateway_api.icat_url,
+            checkCert=Config.config.datagateway_api.icat_check_cert,
         )
 
         test_cache.popitem = MagicMock(side_effect=test_cache.popitem)
@@ -27,7 +27,7 @@ class TestLRUCache:
         def get_cached_client(cache_number, client_pool):
             return test_client
 
-        for cache_number in range(config.datagateway_api.client_cache_size + 1):
+        for cache_number in range(Config.config.datagateway_api.client_cache_size + 1):
             get_cached_client(cache_number, test_pool)
 
         assert test_cache.popitem.called

--- a/test/search_api/test_session_handler.py
+++ b/test/search_api/test_session_handler.py
@@ -1,0 +1,21 @@
+from datagateway_api.src.datagateway_api.icat.icat_client_pool import ICATClient
+from datagateway_api.src.search_api.session_handler import (
+    client_manager,
+    SessionHandler,
+)
+
+
+class TestSessionHandler:
+    def test_session_handler_class(self):
+        assert isinstance(SessionHandler.client, ICATClient)
+
+    def test_client_manager_decorator(self):
+        @client_manager
+        def manage_client():
+            pass
+
+        # Checks that the decorator assigns a session ID, checking one is not present
+        # before the decorator runs
+        assert not SessionHandler.client.sessionId
+        manage_client()
+        assert SessionHandler.client.sessionId

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,44 +6,6 @@ import pytest
 from datagateway_api.src.common.config import APIConfig
 
 
-@pytest.fixture()
-def test_config_data():
-    return {
-        "datagateway_api": {
-            "extension": "/datagateway-api",
-            "backend": "db",
-            "client_cache_size": 5,
-            "client_pool_init_size": 2,
-            "client_pool_max_size": 5,
-            "db_url": "mysql+pymysql://icatdbuser:icatdbuserpw@localhost:3306/icatdb",
-            "icat_url": "https://localhost:8181",
-            "icat_check_cert": False,
-        },
-        "search_api": {
-            "extension": "/search-api",
-            "icat_url": "https://localhost:8181",
-            "icat_check_cert": False,
-            "client_pool_init_size": 2,
-            "client_pool_max_size": 5,
-        },
-        "flask_reloader": False,
-        "log_level": "WARN",
-        "log_location": "/home/runner/work/datagateway-api/datagateway-api/logs.log",
-        "debug_mode": False,
-        "generate_swagger": False,
-        "host": "127.0.0.1",
-        "port": "5000",
-        "test_user_credentials": {"username": "root", "password": "pw"},
-        "test_mechanism": "simple",
-    }
-
-
-@pytest.fixture()
-def test_config(test_config_data):
-    with patch("builtins.open", mock_open(read_data=json.dumps(test_config_data))):
-        return APIConfig.load("test/path")
-
-
 class TestAPIConfig:
     def test_load_with_valid_config_data(self, test_config):
         backend_type = test_config.datagateway_api.backend

--- a/test/test_endpoint_rules.py
+++ b/test/test_endpoint_rules.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.resources.entities.entity_endpoint_dict import endpoints
 
 
@@ -24,7 +24,7 @@ class TestEndpointRules:
 
             for rule in flask_test_app.url_map.iter_rules():
                 if (
-                    f"{config.datagateway_api.extension}"
+                    f"{Config.config.datagateway_api.extension}"
                     f"/{endpoint_entity.lower()}{endpoint_ending}" == rule.rule
                 ):
                     endpoint_found = True
@@ -40,86 +40,87 @@ class TestEndpointRules:
         "endpoint_name, expected_methods",
         [
             pytest.param(
-                f"{config.datagateway_api.extension}/sessions",
+                f"{Config.config.datagateway_api.extension}/sessions",
                 ["DELETE", "GET", "POST", "PUT"],
                 id="sessions",
             ),
             pytest.param(
-                f"{config.datagateway_api.extension}/instruments/<int:id_>"
+                f"{Config.config.datagateway_api.extension}/instruments/<int:id_>"
                 f"/facilitycycles",
                 ["GET"],
                 id="ISIS instrument's facility cycles",
             ),
             pytest.param(
-                f"{config.datagateway_api.extension}/instruments/<int:id_>"
+                f"{Config.config.datagateway_api.extension}/instruments/<int:id_>"
                 f"/facilitycycles/count",
                 ["GET"],
                 id="count ISIS instrument's facility cycles",
             ),
             pytest.param(
-                f"{config.datagateway_api.extension}/instruments/<int:instrument_id>"
-                "/facilitycycles/<int:cycle_id>/investigations",
+                f"{Config.config.datagateway_api.extension}/instruments"
+                "/<int:instrument_id>/facilitycycles/<int:cycle_id>/investigations",
                 ["GET"],
                 id="ISIS investigations",
             ),
             pytest.param(
-                f"{config.datagateway_api.extension}/instruments/<int:instrument_id>"
-                f"/facilitycycles/<int:cycle_id>/investigations/count",
+                f"{Config.config.datagateway_api.extension}/instruments"
+                "/<int:instrument_id>/facilitycycles/<int:cycle_id>/investigations"
+                "/count",
                 ["GET"],
                 id="count ISIS investigations",
             ),
             pytest.param(
-                f"{config.search_api.extension}/datasets",
+                f"{Config.config.search_api.extension}/datasets",
                 ["GET"],
                 id="Search API search datasets",
             ),
             pytest.param(
-                f"{config.search_api.extension}/documents",
+                f"{Config.config.search_api.extension}/documents",
                 ["GET"],
                 id="Search API search documents",
             ),
             pytest.param(
-                f"{config.search_api.extension}/instruments",
+                f"{Config.config.search_api.extension}/instruments",
                 ["GET"],
                 id="Search API search instruments",
             ),
             pytest.param(
-                f"{config.search_api.extension}/datasets/<int:pid>",
+                f"{Config.config.search_api.extension}/datasets/<int:pid>",
                 ["GET"],
                 id="Search API get single dataset",
             ),
             pytest.param(
-                f"{config.search_api.extension}/documents/<int:pid>",
+                f"{Config.config.search_api.extension}/documents/<int:pid>",
                 ["GET"],
                 id="Search API get single document",
             ),
             pytest.param(
-                f"{config.search_api.extension}/instruments/<int:pid>",
+                f"{Config.config.search_api.extension}/instruments/<int:pid>",
                 ["GET"],
                 id="Search API get single instrument",
             ),
             pytest.param(
-                f"{config.search_api.extension}/datasets/count",
+                f"{Config.config.search_api.extension}/datasets/count",
                 ["GET"],
                 id="Search API dataset count",
             ),
             pytest.param(
-                f"{config.search_api.extension}/documents/count",
+                f"{Config.config.search_api.extension}/documents/count",
                 ["GET"],
                 id="Search API document count",
             ),
             pytest.param(
-                f"{config.search_api.extension}/instruments/count",
+                f"{Config.config.search_api.extension}/instruments/count",
                 ["GET"],
                 id="Search API instrument count",
             ),
             pytest.param(
-                f"{config.search_api.extension}/datasets/<int:pid>/files",
+                f"{Config.config.search_api.extension}/datasets/<int:pid>/files",
                 ["GET"],
                 id="Search API get dataset files",
             ),
             pytest.param(
-                f"{config.search_api.extension}/datasets/<int:pid>/files/count",
+                f"{Config.config.search_api.extension}/datasets/<int:pid>/files/count",
                 ["GET"],
                 id="Search API dataset files count",
             ),

--- a/test/test_query_filter.py
+++ b/test/test_query_filter.py
@@ -1,6 +1,6 @@
 import pytest
 
-import datagateway_api.src.common.config as config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.exceptions import ApiError
 from datagateway_api.src.common.filters import QueryFilter
 from datagateway_api.src.datagateway_api.query_filter_factory import QueryFilterFactory
@@ -23,6 +23,6 @@ class TestQueryFilter:
         assert qf.apply_filter(apply_filter) is None
 
     def test_invalid_query_filter_getter(self):
-        config.config.datagateway_api.backend = "invalid_backend"
+        Config.config.datagateway_api.backend = "invalid_backend"
         with pytest.raises(ApiError):
             QueryFilterFactory.get_query_filter({"order": "id DESC"})

--- a/util/icat_db_generator.py
+++ b/util/icat_db_generator.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.datagateway_api.database import models
 
 parser = argparse.ArgumentParser()
@@ -36,7 +36,10 @@ Faker.seed(SEED)
 
 
 engine = create_engine(
-    config.datagateway_api.db_url, poolclass=QueuePool, pool_size=100, max_overflow=0,
+    Config.config.datagateway_api.db_url,
+    poolclass=QueuePool,
+    pool_size=100,
+    max_overflow=0,
 )
 session_factory = sessionmaker(engine)
 session = scoped_session(session_factory)()


### PR DESCRIPTION
This PR will close #258 

## Description
This PR adds a solution for client handling for the search API. Compared with DataGateway API, this is a much more basic solution; because the search API will only ever use the anon user in ICAT, I think a single client object can be used for the API. This client is stored in a `SessionHandler` class which is accessed by the endpoints when they need it. 

The session for this client is managed by the `client_manager` decorator. This is a similar design to `requires_session_id` on DataGateway - i.e. a decorator to be used for endpoints. The client manager decorator looks at the remaining lifetime of the session and if the session has expired, the client will log back in as an anon user. There's no initial login/session ID being set as this use case (i.e. the first time `SessionHandler.client`) is used, a `ICATSessionError` will be caught due to the empty `sessionId` attribute in the client.

I've made use of `ICATClient` for the search API to reduce duplication - this class inherits Python ICAT's `Client` but extends it slightly for the cache object pool design. `client_use` now allows for client configuration for both search API and DataGateway API. 

In terms of testing, I've done some mocking of config (really to test that `client_use` does what I expect it to) so I've moved a couple of pytest fixtures out to `conftest.py`. I've also had to put the config into its own class in `config.py` because otherwise, it cannot be mocked. This is because when `config.py` is imported, the old way (i.e. no in a class) is set as soon as its imported which makes it impossible to mock.

The commits tell a 'nice story' (they're not all over the place and confusing like usual!) so I won't go through each change one-by-one, hopefully looking through each commit gives you a good understanding.

This is a new 'feature', so the new version of the search API will be 3.1.0.

## Testing Instructions
I've done some testing using Apache JMeter and it passes, with no drop in speed (all requests were <600ms on my machine) - 200 'users' are spun up and each send a request to `/datasets`. I'm happy to give the file to the reviewer if this helps.

It should be noted that the ICAT anon authenticator is required for all the tests to pass. This is because `SessionHandler.client` will login using that authenticator. I've made sure the CI has this authenticator by [making a change in ICAT Ansible](https://github.com/icatproject-contrib/icat-ansible/pull/71).
- [x] Review code
- [x] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [x] Review changes to test coverage
- [x] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

## Agile Board Tracking
Connect to #258 
