### PR TITLE
Implement Limit and Skip filters

### DIFF
--- a/datagateway_api/src/datagateway_api/icat/filters.py
+++ b/datagateway_api/src/datagateway_api/icat/filters.py
@@ -210,13 +210,20 @@ class PythonICATOrderFilter(OrderFilter):
 
 
 class PythonICATSkipFilter(SkipFilter):
-    def __init__(self, skip_value):
+    def __init__(self, skip_value, client_use="datagateway_api"):
         super().__init__(skip_value)
+        self.client_use = client_use
 
     def apply_filter(self, query):
-        icat_properties = get_icat_properties(
-            config.datagateway_api.icat_url, config.datagateway_api.icat_check_cert,
-        )
+        if self.client_use == "datagateway_api":
+            icat_properties = get_icat_properties(
+                config.datagateway_api.icat_url, config.datagateway_api.icat_check_cert,
+            )
+        else:
+            icat_properties = get_icat_properties(
+                config.search_api.icat_url, config.search_api.icat_check_cert,
+            )
+
         icat_set_limit(query, self.skip_value, icat_properties["maxEntities"])
 
 

--- a/datagateway_api/src/datagateway_api/icat/filters.py
+++ b/datagateway_api/src/datagateway_api/icat/filters.py
@@ -210,12 +210,12 @@ class PythonICATOrderFilter(OrderFilter):
 
 
 class PythonICATSkipFilter(SkipFilter):
-    def __init__(self, skip_value, client_use="datagateway_api"):
+    def __init__(self, skip_value, filter_use="datagateway_api"):
         super().__init__(skip_value)
-        self.client_use = client_use
+        self.filter_use = filter_use
 
     def apply_filter(self, query):
-        if self.client_use == "datagateway_api":
+        if self.filter_use == "datagateway_api":
             icat_properties = get_icat_properties(
                 config.datagateway_api.icat_url, config.datagateway_api.icat_check_cert,
             )

--- a/datagateway_api/src/search_api/filters.py
+++ b/datagateway_api/src/search_api/filters.py
@@ -19,7 +19,7 @@ class SearchAPIWhereFilter(PythonICATWhereFilter):
 
 class SearchAPISkipFilter(PythonICATSkipFilter):
     def __init__(self, skip_value):
-        super().__init__(skip_value)
+        super().__init__(skip_value, client_use="search_api")
 
     def apply_filter(self, query):
         return super().apply_filter(query)

--- a/datagateway_api/src/search_api/filters.py
+++ b/datagateway_api/src/search_api/filters.py
@@ -19,7 +19,7 @@ class SearchAPIWhereFilter(PythonICATWhereFilter):
 
 class SearchAPISkipFilter(PythonICATSkipFilter):
     def __init__(self, skip_value):
-        super().__init__(skip_value, client_use="search_api")
+        super().__init__(skip_value, filter_use="search_api")
 
     def apply_filter(self, query):
         return super().apply_filter(query)

--- a/test/search_api/conftest.py
+++ b/test/search_api/conftest.py
@@ -1,0 +1,21 @@
+from icat.client import Client
+from icat.query import Query
+import pytest
+
+from datagateway_api.src.common.config import config
+
+
+@pytest.fixture(scope="package")
+def icat_client():
+    client = Client(
+        config.search_api.icat_url, checkCert=config.search_api.icat_check_cert,
+    )
+    client.login(
+        config.test_mechanism, config.test_user_credentials.dict(),
+    )
+    return client
+
+
+@pytest.fixture()
+def icat_query(icat_client):
+    return Query(icat_client, "Investigation")

--- a/test/search_api/conftest.py
+++ b/test/search_api/conftest.py
@@ -2,16 +2,17 @@ from icat.client import Client
 from icat.query import Query
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 
 
 @pytest.fixture(scope="package")
 def icat_client():
     client = Client(
-        config.search_api.icat_url, checkCert=config.search_api.icat_check_cert,
+        Config.config.search_api.icat_url,
+        checkCert=Config.config.search_api.icat_check_cert,
     )
     client.login(
-        config.test_mechanism, config.test_user_credentials.dict(),
+        Config.config.test_mechanism, Config.config.test_user_credentials.dict(),
     )
     return client
 

--- a/test/search_api/test_limit_filter.py
+++ b/test/search_api/test_limit_filter.py
@@ -1,0 +1,28 @@
+import pytest
+
+from datagateway_api.src.common.exceptions import FilterError
+from datagateway_api.src.search_api.filters import SearchAPILimitFilter
+
+
+class TestSearchAPILimitFilter:
+    @pytest.mark.parametrize(
+        "limit_value",
+        [
+            pytest.param(10, id="typical"),
+            pytest.param(0, id="low boundary"),
+            pytest.param(9999, id="high boundary"),
+        ],
+    )
+    def test_valid_limit_value(self, icat_query, limit_value):
+        test_filter = SearchAPILimitFilter(limit_value)
+        test_filter.apply_filter(icat_query)
+
+        assert icat_query.limit == (0, limit_value)
+
+    @pytest.mark.parametrize(
+        "limit_value",
+        [pytest.param(-50, id="extreme invalid"), pytest.param(-1, id="boundary")],
+    )
+    def test_invalid_limit_value(self, icat_query, limit_value):
+        with pytest.raises(FilterError):
+            SearchAPILimitFilter(limit_value)

--- a/test/search_api/test_skip_filter.py
+++ b/test/search_api/test_skip_filter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datagateway_api.src.common.config import config
+from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.exceptions import FilterError
 from datagateway_api.src.common.helpers import get_icat_properties
 from datagateway_api.src.search_api.filters import SearchAPISkipFilter
@@ -17,7 +17,8 @@ class TestSearchAPISkipFilter:
         assert icat_query.limit == (
             skip_value,
             get_icat_properties(
-                config.search_api.icat_url, config.search_api.icat_check_cert,
+                Config.config.search_api.icat_url,
+                Config.config.search_api.icat_check_cert,
             )["maxEntities"],
         )
 

--- a/test/search_api/test_skip_filter.py
+++ b/test/search_api/test_skip_filter.py
@@ -1,0 +1,30 @@
+import pytest
+
+from datagateway_api.src.common.config import config
+from datagateway_api.src.common.exceptions import FilterError
+from datagateway_api.src.common.helpers import get_icat_properties
+from datagateway_api.src.search_api.filters import SearchAPISkipFilter
+
+
+class TestSearchAPISkipFilter:
+    @pytest.mark.parametrize(
+        "skip_value", [pytest.param(10, id="typical"), pytest.param(0, id="boundary")],
+    )
+    def test_valid_skip_value(self, icat_query, skip_value):
+        test_filter = SearchAPISkipFilter(skip_value)
+        test_filter.apply_filter(icat_query)
+
+        assert icat_query.limit == (
+            skip_value,
+            get_icat_properties(
+                config.search_api.icat_url, config.search_api.icat_check_cert,
+            )["maxEntities"],
+        )
+
+    @pytest.mark.parametrize(
+        "skip_value",
+        [pytest.param(-375, id="extreme invalid"), pytest.param(-1, id="boundary")],
+    )
+    def test_invalid_skip_value(self, icat_query, skip_value):
+        with pytest.raises(FilterError):
+            SearchAPISkipFilter(skip_value)


### PR DESCRIPTION
This PR will close #262 
This PR will close #263 

## Description
The Limit (`SearchAPILimitFilter`) and Skip (`SearchAPISkipFilter`) filters are already implemented. To reduce duplication, they inherit from `PythonICATLimitFilter` and `PythonICATSkipFilter`. The `PythonICATSkipFilter` class connects to ICAT to get the `maxEntities` value applying the Skip filter to the ICAT query so this PR refactors the `PythonICATSkipFilter` class to take a `client_use` value in order to allow for client configuration for both Search API and DataGateway API.

It also adds tests which test the `SearchAPILimitFilter` and `SearchAPISkipFilter` classes.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

## Agile Board Tracking
Connect to #262
Connect to #263
