### PR TITLE
Fix CI for Python ICAT Build Issue

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -76,6 +76,13 @@ jobs:
       run: pip install nox==2020.8.22
     - name: Install Poetry
       run: pip install poetry==1.1.9
+
+    # Installing an older version of setuptools for reasons explained at: https://github.com/icatproject/python-icat/issues/99
+    - name: Uninstall setuptools
+      run: poetry run pip uninstall -y setuptools
+    - name: Install older setuptools
+      run: poetry run pip install 'setuptools<58.0.0'
+
     - name: Install dependencies
       run: poetry install
 
@@ -207,6 +214,13 @@ jobs:
         run: cp datagateway_api/config.json.example datagateway_api/config.json
       - name: Install Poetry
         run: pip install poetry==1.1.9
+
+      # Installing an older version of setuptools for reasons explained at: https://github.com/icatproject/python-icat/issues/99
+      - name: Uninstall setuptools
+        run: poetry run pip uninstall -y setuptools
+      - name: Install older setuptools
+        run: poetry run pip install 'setuptools<58.0.0'
+
       - name: Install dependencies
         run: poetry install
 
@@ -251,6 +265,13 @@ jobs:
 
       - name: Create config.json
         run: cp datagateway_api/config.json.example datagateway_api/config.json
+
+      # Installing an older version of setuptools for reasons explained at: https://github.com/icatproject/python-icat/issues/99
+      - name: Uninstall setuptools
+        run: poetry run pip uninstall -y setuptools
+      - name: Install older setuptools
+        run: poetry run pip install 'setuptools<58.0.0'
+
       - name: Install dependencies
         run: poetry install
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -85,5 +85,16 @@ def safety(session):
 @nox.session(python=["3.6", "3.7", "3.8", "3.9"], reuse_venv=True)
 def tests(session):
     args = session.posargs
+    # Installing setuptools that will work with `2to3` which is used when building
+    # `python-icat` < 1.0. 58.0.0 removes support of this tool during builds:
+    # https://setuptools.pypa.io/en/latest/history.html#v58-0-0
+    # Ideally this would be done within `pyproject.toml` but specifying `setuptools` as
+    # a dependency requires Poetry 1.2:
+    # https://github.com/python-poetry/poetry/issues/4511#issuecomment-922420457
+    # Currently, only a pre-release exists for Poetry 1.2. Testing on the pre-release
+    # version didn't fix the `2to3` issue when building Python ICAT, perhaps because
+    # Python ICAT isn't built on the downgraded version for some reason?
+    session.run("poetry", "run", "pip", "uninstall", "-y", "setuptools")
+    session.run("poetry", "run", "pip", "install", "setuptools<58.0.0")
     session.run("poetry", "install", external=True)
     session.run("pytest", *args)


### PR DESCRIPTION
## Description
This PR fixes the CI for an issue first identified on [DataGateway's CI](https://github.com/ral-facilities/datagateway/runs/4701390394?check_suite_focus=true). 

Python ICAT uses `2to3` when building to change certain imports to Python 3 compatible versions. `setuptools` has [removed support of this package from 58.0.0 onwards](https://setuptools.pypa.io/en/latest/history.html#v58-0-0). GitHub Actions was using a version of `setuptools` > 58.0.0, so Python ICAT wouldn't be able to run the Python 2 to 3 code conversion upon building and therefore the code executed contained an import only usable for Python 2.

As such, I've specified that a version less than 58.0.0 should be used when installing the API's dependencies. Ideally, I would've liked to have specified/pinned this in `pyproject.toml`, but my long comment in `noxfile.py` explains why I wasn't able to do that.

## Testing Instructions
Check the CI passes and check that you can run the `tests` Nox session on your machine. I'm able to run it on my Vagrant VM running Centos 7.

There will be no version bump because this only fixes CI/other development tooling.

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?