### PR TITLE
Make ne and neq operators work with non-numeric values

### DIFF
--- a/datagateway_api/src/datagateway_api/icat/filters.py
+++ b/datagateway_api/src/datagateway_api/icat/filters.py
@@ -135,7 +135,7 @@ class PythonICATWhereFilter(WhereFilter):
         # distinct filter is used in a request
         jpql_value = (
             f"{value}"
-            if operator in ("in", "not in", "!=", "between")
+            if operator in ("in", "not in", "between")
             or str(value).startswith("UPPER")
             or "o." in str(value)
             else f"'{value}'"

--- a/test/datagateway_api/icat/filters/test_where_filter.py
+++ b/test/datagateway_api/icat/filters/test_where_filter.py
@@ -10,8 +10,8 @@ class TestICATWhereFilter:
         "operation, value, expected_condition_value",
         [
             pytest.param("eq", 5, ["%s = '5'"], id="equal"),
-            pytest.param("ne", 5, ["%s != 5"], id="not equal (ne)"),
-            pytest.param("neq", 5, ["%s != 5"], id="not equal (neq)"),
+            pytest.param("ne", 5, ["%s != '5'"], id="not equal (ne)"),
+            pytest.param("neq", 5, ["%s != '5'"], id="not equal (neq)"),
             pytest.param("like", 5, ["%s like '%%5%%'"], id="like"),
             pytest.param("ilike", 5, ["UPPER(%s) like UPPER('%%5%%')"], id="ilike"),
             pytest.param("nlike", 5, ["%s not like '%%5%%'"], id="not like"),

--- a/test/search_api/filters/test_search_api_where_filter.py
+++ b/test/search_api/filters/test_search_api_where_filter.py
@@ -19,7 +19,7 @@ class TestSearchAPIWhereFilter:
             pytest.param(
                 SearchAPIWhereFilter("title", "My Dataset 1", "ne"),
                 "Dataset",
-                "SELECT o FROM Dataset o WHERE o.name != My Dataset 1",
+                "SELECT o FROM Dataset o WHERE o.name != 'My Dataset 1'",
                 id="WHERE filter with non-default operator",
             ),
             pytest.param(


### PR DESCRIPTION
This PR will close #315 

## Description
Makes changes so that values passed with the `ne` and `neq` operators are put inside quotes, just like it is done with the `eq` operator.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] Sending `http://{{datagateway-api}}/datagateway-api/datasets?limit=50&where={"name": {"neq": "DATASET 1"}}` should return all Datasets whose `name` field value is not equal to `DATASET 1`

## Agile Board Tracking
Connect to #315 
