### PR TITLE
Empty Where Filter Input on Count Endpoints

### DIFF
--- a/datagateway_api/src/search_api/helpers.py
+++ b/datagateway_api/src/search_api/helpers.py
@@ -146,6 +146,9 @@ def get_files(entity_name, pid, filters):
         "Entity Name: %s, Filters: %s", entity_name, filters,
     )
 
+    # Check if dataset with such pid exists before proceeding
+    get_with_pid("Dataset", pid, [])
+
     filters.append(SearchAPIWhereFilter("dataset.pid", pid, "eq"))
     return get_search(entity_name, filters)
 

--- a/datagateway_api/src/search_api/helpers.py
+++ b/datagateway_api/src/search_api/helpers.py
@@ -174,5 +174,8 @@ def get_files_count(entity_name, filters, pid):
         "Entity Name: %s, Filters: %s", entity_name, filters,
     )
 
+    # Check if dataset with such pid exists before proceeding
+    get_with_pid("Dataset", pid, [])
+
     filters.append(SearchAPIWhereFilter("dataset.pid", pid, "eq"))
     return get_count(entity_name, filters)

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -103,6 +103,7 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
         :type entity_name: :class:`str`
         :return: The list of `NestedWhereFilters` and/ or `SearchAPIWhereFilter` objects
             created
+        :raises FilterError: If the where filter input is not provided as an object
         """
         if not isinstance(where_filter_input, dict):
             raise FilterError(

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -147,10 +147,10 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
                 log.debug("Text operator found within JSON where object")
                 try:
                     entity_class = getattr(search_api_models, entity_name)
-                except AttributeError as e:
+                except AttributeError:
                     raise SearchAPIError(
-                        f"No text operator fields have been defined for {entity_name}"
-                        f", {e.args}",
+                        f"No model for {entity_name} could be found, a different entity"
+                        f"name should be used",
                     )
 
                 or_conditional_filters = []

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -104,6 +104,11 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
         :return: The list of `NestedWhereFilters` and/ or `SearchAPIWhereFilter` objects
             created
         """
+        if not isinstance(where_filter_input, dict):
+            raise FilterError(
+                "Bad where filter input, please ensure that it is provided as an "
+                "object",
+            )
 
         where_filters = []
         if where_filter_input:

--- a/test/search_api/endpoints/test_count_dataset_files.py
+++ b/test/search_api/endpoints/test_count_dataset_files.py
@@ -37,9 +37,6 @@ class TestSearchAPICountDatasetFilesEndpoint:
                 {"count": 0},
                 id="Count dataset files with filter to return zero count",
             ),
-            pytest.param(
-                "unknown pid", "{}", {"count": 0}, id="Non-existent dataset pid",
-            ),
         ],
     )
     def test_valid_count_dataset_files_endpoint(
@@ -54,22 +51,24 @@ class TestSearchAPICountDatasetFilesEndpoint:
         assert test_response.json == expected_json
 
     @pytest.mark.parametrize(
-        "pid, request_filter",
+        "pid, request_filter, expected_status_code",
         [
-            pytest.param("0-8401-1070-7", '{"bad filter"}', id="Bad filter"),
+            pytest.param("0-8401-1070-7", '{"bad filter"}', 400, id="Bad filter"),
             pytest.param(
                 "0-8401-1070-7",
                 '{"where": {"name": "FILE 4"}}',
+                400,
                 id="Where filter inside where query param",
             ),
+            pytest.param("my 404 test pid", "{}", 404, id="Non-existent dataset pid"),
         ],
     )
     def test_invalid_count_dataset_files_endpoint(
-        self, flask_test_app_search_api, pid, request_filter,
+        self, flask_test_app_search_api, pid, request_filter, expected_status_code,
     ):
         test_response = flask_test_app_search_api.get(
             f"{Config.config.search_api.extension}/datasets/{pid}/files/count"
             f"?where={request_filter}",
         )
 
-        assert test_response.status_code == 400
+        assert test_response.status_code == expected_status_code

--- a/test/search_api/endpoints/test_count_dataset_files.py
+++ b/test/search_api/endpoints/test_count_dataset_files.py
@@ -12,8 +12,6 @@ class TestSearchAPICountDatasetFilesEndpoint:
                 "{}",
                 {"count": 56},
                 id="Basic /datasets/{pid}/files/count request",
-                # Skipped because empty dict for filter doesn't work on where
-                marks=pytest.mark.skip,
             ),
             pytest.param(
                 "0-8401-1070-7",
@@ -40,12 +38,7 @@ class TestSearchAPICountDatasetFilesEndpoint:
                 id="Count dataset files with filter to return zero count",
             ),
             pytest.param(
-                "unknown pid",
-                "{}",
-                {"count": 0},
-                id="Non-existent dataset pid",
-                # Skipped because empty dict for filter doesn't work on where
-                marks=pytest.mark.skip,
+                "unknown pid", "{}", {"count": 0}, id="Non-existent dataset pid",
             ),
         ],
     )

--- a/test/search_api/endpoints/test_count_endpoint.py
+++ b/test/search_api/endpoints/test_count_endpoint.py
@@ -8,28 +8,16 @@ class TestSearchAPICountEndpoint:
         "endpoint_name, request_filter, expected_json",
         [
             pytest.param(
-                "datasets",
-                "{}",
-                {"count": 479},
-                id="Basic /datasets/count request",
-                # Skipped because empty dict for filter doesn't work on where
-                marks=pytest.mark.skip,
+                "datasets", "{}", {"count": 479}, id="Basic /datasets/count request",
             ),
             pytest.param(
-                "documents",
-                "{}",
-                {"count": 239},
-                id="Basic /documents/count request",
-                # Skipped because empty dict for filter doesn't work on where
-                marks=pytest.mark.skip,
+                "documents", "{}", {"count": 239}, id="Basic /documents/count request",
             ),
             pytest.param(
                 "instruments",
                 "{}",
                 {"count": 14},
                 id="Basic /instruments/count request",
-                # Skipped because empty dict for filter doesn't work on where
-                marks=pytest.mark.skip,
             ),
             pytest.param(
                 "datasets",

--- a/test/search_api/endpoints/test_get_dataset_files.py
+++ b/test/search_api/endpoints/test_get_dataset_files.py
@@ -141,14 +141,7 @@ class TestSearchAPIGetDatasetFilesEndpoint:
             pytest.param(
                 "0-8401-1070-7", '{"include": ""}', 400, id="Bad include filter",
             ),
-            pytest.param(
-                "my 404 test pid",
-                "{}",
-                404,
-                id="Non-existent dataset pid",
-                # Skipped because this actually returns 200
-                marks=pytest.mark.skip,
-            ),
+            pytest.param("my 404 test pid", "{}", 404, id="Non-existent dataset pid"),
         ],
     )
     def test_invalid_get_dataset_files_endpoint(

--- a/test/search_api/test_search_api_query_filter_factory.py
+++ b/test/search_api/test_search_api_query_filter_factory.py
@@ -2063,6 +2063,7 @@ class TestSearchAPIQueryFilterFactory:
                 },
                 id="Unsupported skip filter in scope of include filter",
             ),
+            pytest.param({"filter": {"where": []}}, id="Bad where filter input"),
             pytest.param(
                 {"filter": {"where": {"isPublic": {"lt": True}}}},
                 id="Unsupported operator in where filter with boolean value",


### PR DESCRIPTION
This PR will close #309 

## Description
The changes in this PR make the count endpoints work when they receive an empty where filter input (`where={}`). Also added some extra code so that `FilterError` is raised when the where filter input is not an object.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?