### PR TITLE
Wrong calculation for isPublic field values

### DIFF
--- a/datagateway_api/config.json.example
+++ b/datagateway_api/config.json.example
@@ -12,8 +12,7 @@
     "search_api": {
         "extension": "/search-api",
         "icat_url": "https://localhost:8181",
-        "icat_check_cert": false,
-        "num_of_years_determining_public_data": 3
+        "icat_check_cert": false
     },
     "flask_reloader": false,
     "log_level": "WARN",

--- a/datagateway_api/search_api_mapping.json.example
+++ b/datagateway_api/search_api_mapping.json.example
@@ -12,7 +12,7 @@
         "base_icat_entity": "Dataset",
         "pid": ["doi", "id"],
         "title": "name",
-        "isPublic": "createTime",
+        "isPublic": "",
         "creationDate": "createTime",
         "size": "",
         "documents": {"Document": "investigation"},
@@ -25,7 +25,7 @@
     "Document": {
         "base_icat_entity": "Investigation",
         "pid": ["doi", "id"],
-        "isPublic": "releaseDate",
+        "isPublic": "",
         "type": "type.name",
         "title": "name",
         "summary": "summary",

--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -130,7 +130,6 @@ class SearchAPI(BaseModel):
     extension: StrictStr
     icat_check_cert: StrictBool
     icat_url: StrictStr
-    num_of_years_determining_public_data: StrictInt
 
     _validate_extension = validator("extension", allow_reuse=True)(validate_extension)
 

--- a/datagateway_api/src/search_api/models.py
+++ b/datagateway_api/src/search_api/models.py
@@ -1,14 +1,11 @@
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+from datetime import datetime
 import sys
 from typing import ClassVar, List, Optional, Union
 
-from dateutil.relativedelta import relativedelta
-from pydantic import BaseModel, Field, ValidationError, validator
+from pydantic import BaseModel, Field, root_validator, ValidationError, validator
 from pydantic.error_wrappers import ErrorWrapper
 
-from datagateway_api.src.common.config import Config
-from datagateway_api.src.common.date_handler import DateHandler
 from datagateway_api.src.search_api.panosc_mappings import mappings
 
 
@@ -195,17 +192,12 @@ class Dataset(PaNOSCAttribute):
     def set_pid(cls, value):  # noqa: B902, N805
         return f"pid:{value}" if isinstance(value, int) else value
 
-    @validator("is_public", pre=True, always=True)
-    def set_is_public(cls, value):  # noqa: B902, N805
-        if not value:
-            return value
-
-        creation_date = DateHandler.str_to_datetime_object(value)
-        current_datetime = datetime.now(timezone.utc)
-        rd = relativedelta(
-            years=Config.config.search_api.num_of_years_determining_public_data,
-        )
-        return creation_date < (current_datetime - rd)
+    @root_validator(pre=True)
+    def set_is_public(cls, values):  # noqa: B902, N805
+        # Hardcoding this to True because anon user is used for querying so all data
+        # returned by it is public
+        values["isPublic"] = True
+        return values
 
     @classmethod
     def from_icat(cls, icat_data, required_related_fields):
@@ -240,17 +232,12 @@ class Document(PaNOSCAttribute):
     def set_pid(cls, value):  # noqa: B902, N805
         return f"pid:{value}" if isinstance(value, int) else value
 
-    @validator("is_public", pre=True, always=True)
-    def set_is_public(cls, value):  # noqa: B902, N805
-        if not value:
-            return value
-
-        creation_date = DateHandler.str_to_datetime_object(value)
-        current_datetime = datetime.now(timezone.utc)
-        rd = relativedelta(
-            years=Config.config.search_api.num_of_years_determining_public_data,
-        )
-        return creation_date < (current_datetime - rd)
+    @root_validator(pre=True)
+    def set_is_public(cls, values):  # noqa: B902, N805
+        # Hardcoding this to True because anon user is used for querying so all data
+        # returned by it is public
+        values["isPublic"] = True
+        return values
 
     @classmethod
     def from_icat(cls, icat_data, required_related_fields):

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -172,16 +172,14 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
                 )
         else:
             log.info("Basic where filter found, extracting field, value and operation")
-            filter_data = SearchAPIQueryFilterFactory.get_condition_values(
+            field, value, operation = SearchAPIQueryFilterFactory.get_condition_values(
                 where_filter_input,
             )
-            where_filters.append(
-                SearchAPIWhereFilter(
-                    field=filter_data[0],
-                    value=filter_data[1],
-                    operation=filter_data[2],
-                ),
-            )
+
+            # Ignore filters on `isPublic`` fields as data is always public. This is
+            # hardcoded in the `models.py` module.
+            if field != "isPublic":
+                where_filters.append(SearchAPIWhereFilter(field, value, operation))
 
         return where_filters
 

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -176,9 +176,14 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
                 where_filter_input,
             )
 
-            # Ignore filters on `isPublic`` fields as data is always public. This is
-            # hardcoded in the `models.py` module.
-            if field != "isPublic":
+            # Ignore filters on `isPublic`` fields as data is always public. Ensure that
+            # empty list is returned when filtering for non-public data.
+            if field == "isPublic":
+                value = not value if operation == "neq" else value
+                if not value:
+                    where_filters.append(SearchAPISkipFilter(1))
+                    where_filters.append(SearchAPILimitFilter(0))
+            else:
                 where_filters.append(SearchAPIWhereFilter(field, value, operation))
 
         return where_filters

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -1,10 +1,7 @@
-from datetime import datetime, timezone
 import logging
 
-from dateutil.relativedelta import relativedelta
 
 from datagateway_api.src.common.base_query_filter_factory import QueryFilterFactory
-from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.exceptions import FilterError, SearchAPIError
 from datagateway_api.src.search_api.filters import (
     SearchAPIIncludeFilter,
@@ -300,14 +297,6 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
                     "Bad Where filter: Invalid operator used with boolean value",
                 )
 
-        if field == "isPublic":
-            (
-                value,
-                operation,
-            ) = SearchAPIQueryFilterFactory.convert_is_public_field_value_and_operation(
-                value, operation,
-            )
-
         return field, value, operation
 
     @staticmethod
@@ -344,36 +333,3 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
                     )
             if isinstance(where_filter, SearchAPIWhereFilter):
                 where_filter.field = f"{entity_name}.{where_filter.field}"
-
-    @staticmethod
-    def convert_is_public_field_value_and_operation(value, operation):
-        """
-        The ICAT mappings for the isPublic PaNOSC fields are not direct and as a result
-        of this, we calculate whether data is public or not at the Search API level.
-        For example, in the case of ISIS, Dataset's isPublic field maps to Dataset's
-        createTime field in ICAT. We take this datetime value and determine whether it
-        is public or not by checking whether the datetime is more than 3 years ago or
-        not. The isPublic fields are of type boolean so any WHERE filter applied to
-        them will have a value that is boolean too. As a result of this, the value and
-        operation need to be converted to a format appropriate for the mapped ICAT
-        field. In the example above, if the filter asks for all Datasets whose isPublic
-        fields are set to True to be returned, then this method changes the WHERE
-        filter value to a three years ago datetime value and the operator to less than
-        so that all Datasets older than 3 years (which ISIS considers public) are
-        returned.
-        """
-        value = not value if operation == "neq" else value
-        if value is True:
-            operation = "lt"
-        else:
-            operation = "gt"
-
-        current_datetime = datetime.now(timezone.utc)
-        rd = relativedelta(
-            years=Config.config.search_api.num_of_years_determining_public_data,
-        )
-        # The timezone part has a plus sign so replacing
-        # with a blank space to avoid issues
-        value = str(current_datetime - rd).replace("+", " ")
-
-        return value, operation

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -104,7 +104,6 @@ def test_config_data():
             "extension": "/search-api",
             "icat_url": "https://localhost.testdomain:8181",
             "icat_check_cert": True,
-            "num_of_years_determining_public_data": 3,
         },
         "flask_reloader": False,
         "log_level": "WARN",

--- a/test/search_api/conftest.py
+++ b/test/search_api/conftest.py
@@ -43,7 +43,7 @@ def test_search_api_mappings_data():
             "base_icat_entity": "Dataset",
             "pid": ["doi", "id"],
             "title": "name",
-            "isPublic": "createTime",
+            "isPublic": "",
             "creationDate": "createTime",
             "size": "",
             "documents": {"Document": "investigation"},
@@ -56,7 +56,7 @@ def test_search_api_mappings_data():
         "Document": {
             "base_icat_entity": "Investigation",
             "pid": ["doi", "id"],
-            "isPublic": "releaseDate",
+            "isPublic": "",
             "type": "type.name",
             "title": "name",
             "summary": "summary",

--- a/test/search_api/endpoints/test_count_endpoint.py
+++ b/test/search_api/endpoints/test_count_endpoint.py
@@ -95,13 +95,13 @@ class TestSearchAPICountEndpoint:
             pytest.param(
                 "datasets",
                 '{"isPublic": true}',
-                {"count": 462},
+                {"count": 479},
                 id="Dataset count with isPublic condition",
             ),
             pytest.param(
                 "documents",
                 '{"isPublic": true}',
-                {"count": 76},
+                {"count": 239},
                 id="Document count with isPublic condition",
             ),
         ],

--- a/test/search_api/endpoints/test_count_endpoint.py
+++ b/test/search_api/endpoints/test_count_endpoint.py
@@ -93,13 +93,29 @@ class TestSearchAPICountEndpoint:
                 "datasets",
                 '{"isPublic": true}',
                 {"count": 479},
-                id="Dataset count with isPublic condition",
+                id="Dataset count with isPublic condition (True)",
             ),
             pytest.param(
                 "documents",
                 '{"isPublic": true}',
                 {"count": 239},
-                id="Document count with isPublic condition",
+                id="Document count with isPublic condition (True)",
+            ),
+            pytest.param(
+                "datasets",
+                '{"isPublic": false}',
+                {"count": 0},
+                id="Dataset count with isPublic condition (False)",
+                # Skipped due to skip filter causing issue on count endpoints
+                marks=pytest.mark.skip,
+            ),
+            pytest.param(
+                "documents",
+                '{"isPublic": false}',
+                {"count": 0},
+                id="Document count with isPublic condition (False)",
+                # Skipped due to skip filter causing issue on count endpoints
+                marks=pytest.mark.skip,
             ),
         ],
     )

--- a/test/search_api/endpoints/test_count_endpoint.py
+++ b/test/search_api/endpoints/test_count_endpoint.py
@@ -1,9 +1,6 @@
-from unittest.mock import patch
-
 import pytest
 
 from datagateway_api.src.common.config import Config
-from datagateway_api.src.common.date_handler import DateHandler
 
 
 class TestSearchAPICountEndpoint:
@@ -106,27 +103,9 @@ class TestSearchAPICountEndpoint:
             ),
         ],
     )
-    @patch("datagateway_api.src.search_api.query_filter_factory.datetime")
     def test_valid_count_endpoint_is_public_field(
-        self,
-        datetime_mock,
-        flask_test_app_search_api,
-        endpoint_name,
-        request_filter,
-        expected_json,
+        self, flask_test_app_search_api, endpoint_name, request_filter, expected_json,
     ):
-        """
-        The datetime must be mocked here to prevent tests from failing as time passes.
-        A dataset or document that was created or released 2 years and 364 ago would be
-        fall in the not public category, however that same dataset or document would
-        fall in the public category (in the case of ISIS) a few days later because it
-        will be 3 years old. As a result of this, the tests will fail because the actual
-        count will be different to that of the expected. Mocking datetime takes care of
-        this issue because it sets the time to the one provided in this test method.
-        """
-        datetime_mock.now.return_value = DateHandler.str_to_datetime_object(
-            "2022-02-06 00:00:01+00:00",
-        )
         test_response = flask_test_app_search_api.get(
             f"{Config.config.search_api.extension}/{endpoint_name}/count?where="
             f"{request_filter}",

--- a/test/search_api/endpoints/test_search_endpoint.py
+++ b/test/search_api/endpoints/test_search_endpoint.py
@@ -416,7 +416,13 @@ class TestSearchAPISearchEndpoint:
                         "samples": [],
                     },
                 ],
-                id="Search datasets with isPublic condition",
+                id="Search datasets with isPublic condition (True)",
+            ),
+            pytest.param(
+                "datasets",
+                '{"where": {"isPublic": false}}',
+                [],
+                id="Search datasets with isPublic condition (False)",
             ),
         ],
     )

--- a/test/search_api/test_models.py
+++ b/test/search_api/test_models.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timezone
-
 from pydantic import ValidationError
 import pytest
 
@@ -88,7 +86,7 @@ INSTRUMENT_ICAT_DATA = {
 INVESTIGATION_ICAT_DATA = {
     "endDate": "2000-12-31 00:00:00+00:00",
     "name": "Test name",
-    "releaseDate": str(datetime.now(timezone.utc)),
+    "releaseDate": "2000-12-31 00:00:00+00:00",
     "id": 1,
     "modTime": "2000-12-31 00:00:00+00:00",
     "modId": "Test modId",
@@ -216,7 +214,7 @@ DATASET_PANOSC_DATA = {
 
 DOCUMENT_PANOSC_DATA = {
     "pid": INVESTIGATION_ICAT_DATA["doi"],
-    "isPublic": False,
+    "isPublic": True,
     "type": INVESTIGATION_TYPE_ICAT_DATA["name"],
     "title": INVESTIGATION_ICAT_DATA["name"],
     "summary": INVESTIGATION_ICAT_DATA["summary"],

--- a/test/search_api/test_search_api_query_filter_factory.py
+++ b/test/search_api/test_search_api_query_filter_factory.py
@@ -1,7 +1,3 @@
-from datetime import datetime, timezone
-from unittest.mock import patch
-
-from dateutil.relativedelta import relativedelta
 import pytest
 
 from datagateway_api.src.common.exceptions import FilterError
@@ -17,13 +13,6 @@ from datagateway_api.src.search_api.query_filter_factory import (
     SearchAPIQueryFilterFactory,
 )
 
-DATETIME_NOW = datetime.now(timezone.utc)
-
-
-def get_three_years_ago_datetime_as_string():
-    three_years_ago = DATETIME_NOW - relativedelta(years=3)
-    return str(three_years_ago).replace("+", " ")
-
 
 class TestSearchAPIQueryFilterFactory:
     @pytest.mark.parametrize(
@@ -36,44 +25,10 @@ class TestSearchAPIQueryFilterFactory:
                 id="Property value with no operator",
             ),
             pytest.param(
-                {"filter": {"where": {"isPublic": False}}},
-                "Document",
-                SearchAPIWhereFilter(
-                    "isPublic", get_three_years_ago_datetime_as_string(), "gt",
-                ),
-                id="Property value with no operator (isPublic field - False value)",
-            ),
-            pytest.param(
-                {"filter": {"where": {"isPublic": True}}},
-                "Document",
-                SearchAPIWhereFilter(
-                    "isPublic", get_three_years_ago_datetime_as_string(), "lt",
-                ),
-                id="Property value with no operator (isPublic field - True value)",
-            ),
-            pytest.param(
                 {"filter": {"where": {"summary": {"like": "My Test Summary"}}}},
                 "Document",
                 SearchAPIWhereFilter("summary", "My Test Summary", "like"),
                 id="Property value with operator",
-            ),
-            pytest.param(
-                {"filter": {"where": {"isPublic": {"neq": False}}}},
-                "Document",
-                SearchAPIWhereFilter(
-                    "isPublic", get_three_years_ago_datetime_as_string(), "lt",
-                ),
-                id="Property value with operator (isPublic field - False value - neq "
-                "operator)",
-            ),
-            pytest.param(
-                {"filter": {"where": {"isPublic": {"neq": True}}}},
-                "Document",
-                SearchAPIWhereFilter(
-                    "isPublic", get_three_years_ago_datetime_as_string(), "gt",
-                ),
-                id="Property value with operator (isPublic field - True value - neq "
-                "operator)",
             ),
             pytest.param(
                 {"where": {"summary": {"like": "My Test Summary"}}},
@@ -83,11 +38,9 @@ class TestSearchAPIQueryFilterFactory:
             ),
         ],
     )
-    @patch("datagateway_api.src.search_api.query_filter_factory.datetime")
     def test_valid_where_filter(
-        self, datetime_mock, test_request_filter, test_entity_name, expected_where,
+        self, test_request_filter, test_entity_name, expected_where,
     ):
-        datetime_mock.now.return_value = DATETIME_NOW
         filters = SearchAPIQueryFilterFactory.get_query_filter(
             test_request_filter, test_entity_name,
         )


### PR DESCRIPTION
This PR will close #329 

## Description

From the issue description:
_At the moment, we set the Document's `isPublic` field value based on the Investigation's `releaseDate` ICAT field so if it was released more than 3 years ago then it is set to `True`. This is wrong because `releaseDate` is the date it was released publicly so the check should instead be `releaseDate <= today`. We do the same for the Dataset's `isPublic` field value but instead use the Dataset's `createTime` ICAT field which is not the correct field to be used. Instead we need to use the parent Investigation's `releaseDate` field to determine if it is public or not._

During my investigation of this issue, I noticed that calibration investigations have a `releaseDate` in future but they are considered public which meant that the `releaseDate <= today` check from above did not work when setting `isPublic` at the Search API level. As a result of this, in this PR, I have chosen to implement the alternative solution that I described in the issue description which is to do with hardcoding so that the Search API returns `True` for the `isPublic` fields and ignoring any filter on those fields. This meant that the changes related to the `isPublic` field from #322 had to be removed as part of this PR.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] All returned Dataset records have `isPublic` set to `True`
- [ ] All returned Document records have `isPublic` set to `True`