### PR TITLE
Search API Error Signalling/Formatting

### DIFF
--- a/datagateway_api/src/api_start_utils.py
+++ b/datagateway_api/src/api_start_utils.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 
 from apispec import APISpec
+from flask import Response
 from flask_cors import CORS
 from flask_restful import Api
 from flask_swagger_ui import get_swaggerui_blueprint
@@ -55,7 +56,12 @@ class CustomErrorHandledApi(Api):
     """
 
     def handle_error(self, e):
-        return str(e), e.status_code
+        if isinstance(e.args[0], (str, dict, tuple, Response)):
+            error_msg = e.args[0]
+        else:
+            error_msg = str(e)
+
+        return error_msg, e.status_code
 
 
 def create_app_infrastructure(flask_app):

--- a/datagateway_api/src/resources/search_api_endpoints.py
+++ b/datagateway_api/src/resources/search_api_endpoints.py
@@ -9,6 +9,7 @@ from datagateway_api.src.search_api.helpers import (
     get_files_count,
     get_search,
     get_with_pid,
+    search_api_error_handling,
 )
 
 log = logging.getLogger()
@@ -26,6 +27,7 @@ def get_search_endpoint(entity_name):
     """
 
     class Endpoint(Resource):
+        @search_api_error_handling
         def get(self):
             filters = get_filters_from_query_string("search_api", entity_name)
             log.debug("Filters: %s", filters)
@@ -49,6 +51,7 @@ def get_single_endpoint(entity_name):
     """
 
     class EndpointWithID(Resource):
+        @search_api_error_handling
         def get(self, pid):
             filters = get_filters_from_query_string("search_api", entity_name)
             log.debug("Filters: %s", filters)
@@ -72,6 +75,7 @@ def get_number_count_endpoint(entity_name):
     """
 
     class CountEndpoint(Resource):
+        @search_api_error_handling
         def get(self):
             # Only WHERE included on count endpoints
             filters = get_filters_from_query_string("search_api", entity_name)
@@ -96,6 +100,7 @@ def get_files_endpoint(entity_name):
     """
 
     class FilesEndpoint(Resource):
+        @search_api_error_handling
         def get(self, pid):
             filters = get_filters_from_query_string("search_api", entity_name)
             log.debug("Filters: %s", filters)
@@ -120,6 +125,7 @@ def get_number_count_files_endpoint(entity_name):
     """
 
     class CountFilesEndpoint(Resource):
+        @search_api_error_handling
         def get(self, pid):
             # Only WHERE included on count endpoints
             filters = get_filters_from_query_string("search_api", entity_name)

--- a/test/search_api/test_error_handling.py
+++ b/test/search_api/test_error_handling.py
@@ -1,0 +1,42 @@
+import pytest
+
+from datagateway_api.src.common.exceptions import (
+    BadRequestError,
+    FilterError,
+    MissingRecordError,
+    SearchAPIError,
+)
+from datagateway_api.src.search_api.helpers import search_api_error_handling
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "raised_exception, expected_exception, status_code",
+        [
+            pytest.param(BadRequestError, BadRequestError, 400, id="Bad request error"),
+            pytest.param(FilterError, FilterError, 400, id="Invalid filter"),
+            pytest.param(
+                MissingRecordError, MissingRecordError, 404, id="Missing record",
+            ),
+            pytest.param(SearchAPIError, SearchAPIError, 500, id="Search API error"),
+            pytest.param(TypeError, BadRequestError, 400, id="Type error"),
+            pytest.param(ValueError, BadRequestError, 400, id="Value error"),
+            pytest.param(AttributeError, BadRequestError, 400, id="Attribute error"),
+        ],
+    )
+    def test_valid_error_raised(
+        self, raised_exception, expected_exception, status_code,
+    ):
+        @search_api_error_handling
+        def raise_exception():
+            raise raised_exception()
+
+        try:
+            raise_exception()
+        except Exception as e:
+            assert isinstance(e.args[0], dict)
+            assert e.status_code == status_code
+            assert list(e.args[0]["error"].keys()) == ["statusCode", "name", "message"]
+
+        with pytest.raises(expected_exception):
+            raise_exception()

--- a/test/test_queries_records.py
+++ b/test/test_queries_records.py
@@ -30,7 +30,10 @@ class TestQueriesRecords:
         def raise_exception():
             raise raised_exception()
 
-        with pytest.raises(expected_exception) as ctx:
+        try:
             raise_exception()
+        except Exception as e:
+            assert e.status_code == status_code
 
-            assert ctx.exception.status_code == status_code
+        with pytest.raises(expected_exception):
+            raise_exception()


### PR DESCRIPTION
This PR will close #296 

## Description
This PR adds a decorator so 4xx/5xx responses are formatted as per the specification (see the linked issue for what that should be). This decorator is applied to each of the search API endpoint functions in `search_api_endpoints.py`. This is a similar solution to handling errors for DataGateway API (`@queries_records`). 

## Testing Instructions
The automated tests follow the same mechanism as the `queries_records` decorator so I've the same thing for this code. For manual testing, try and get 4xx/5xx responses and check the response body matches the format in the original issue.

`poetry run semantic-release print-version` shows 4.1.0 which is what I expect the version bump to be.

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

## Agile Board Tracking
Connect to #296 
