### PR TITLE
Return 404 on /files and /files/count endpoints with non-existent dataset pid

### DIFF
--- a/datagateway_api/src/search_api/helpers.py
+++ b/datagateway_api/src/search_api/helpers.py
@@ -146,6 +146,9 @@ def get_files(entity_name, pid, filters):
         "Entity Name: %s, Filters: %s", entity_name, filters,
     )
 
+    # Check if dataset with such pid exists before proceeding
+    get_with_pid("Dataset", pid, [])
+
     filters.append(SearchAPIWhereFilter("dataset.pid", pid, "eq"))
     return get_search(entity_name, filters)
 

--- a/datagateway_api/src/search_api/helpers.py
+++ b/datagateway_api/src/search_api/helpers.py
@@ -174,5 +174,8 @@ def get_files_count(entity_name, filters, pid):
         "Entity Name: %s, Filters: %s", entity_name, filters,
     )
 
+    # Check if dataset with such pid exists before proceeding
+    get_with_pid("Dataset", pid, [])
+
     filters.append(SearchAPIWhereFilter("dataset.pid", pid, "eq"))
     return get_count(entity_name, filters)

--- a/test/search_api/endpoints/test_count_dataset_files.py
+++ b/test/search_api/endpoints/test_count_dataset_files.py
@@ -37,9 +37,6 @@ class TestSearchAPICountDatasetFilesEndpoint:
                 {"count": 0},
                 id="Count dataset files with filter to return zero count",
             ),
-            pytest.param(
-                "unknown pid", "{}", {"count": 0}, id="Non-existent dataset pid",
-            ),
         ],
     )
     def test_valid_count_dataset_files_endpoint(
@@ -54,22 +51,24 @@ class TestSearchAPICountDatasetFilesEndpoint:
         assert test_response.json == expected_json
 
     @pytest.mark.parametrize(
-        "pid, request_filter",
+        "pid, request_filter, expected_status_code",
         [
-            pytest.param("0-8401-1070-7", '{"bad filter"}', id="Bad filter"),
+            pytest.param("0-8401-1070-7", '{"bad filter"}', 400, id="Bad filter"),
             pytest.param(
                 "0-8401-1070-7",
                 '{"where": {"name": "FILE 4"}}',
+                400,
                 id="Where filter inside where query param",
             ),
+            pytest.param("my 404 test pid", "{}", 404, id="Non-existent dataset pid"),
         ],
     )
     def test_invalid_count_dataset_files_endpoint(
-        self, flask_test_app_search_api, pid, request_filter,
+        self, flask_test_app_search_api, pid, request_filter, expected_status_code,
     ):
         test_response = flask_test_app_search_api.get(
             f"{Config.config.search_api.extension}/datasets/{pid}/files/count"
             f"?where={request_filter}",
         )
 
-        assert test_response.status_code == 400
+        assert test_response.status_code == expected_status_code

--- a/test/search_api/endpoints/test_get_dataset_files.py
+++ b/test/search_api/endpoints/test_get_dataset_files.py
@@ -141,14 +141,7 @@ class TestSearchAPIGetDatasetFilesEndpoint:
             pytest.param(
                 "0-8401-1070-7", '{"include": ""}', 400, id="Bad include filter",
             ),
-            pytest.param(
-                "my 404 test pid",
-                "{}",
-                404,
-                id="Non-existent dataset pid",
-                # Skipped because this actually returns 200
-                marks=pytest.mark.skip,
-            ),
+            pytest.param("my 404 test pid", "{}", 404, id="Non-existent dataset pid"),
         ],
     )
     def test_invalid_get_dataset_files_endpoint(


### PR DESCRIPTION
This PR will close #327 

## Description
Returns `404 NOT FOUND` `No result found` when non-existent dataset `pid` is used with the `/files` and `/files/count` dataset endpoints. This was achieved by calling the `get_with_pid ` at the the begging of the `get_files` and `get_files_count` methods as it is designed to deal with that case.

I tried adding a `PythonICATDistinctFieldFilter` to the list of filters passed to `get_with_pid` as per the suggestion in https://github.com/ral-facilities/datagateway-api/issues/327#issuecomment-1038776072, however I could not get it to work because the `SearchAPIQuery` object created in the `get_search` method does not have an `aggregate` so it fails with `AttributeError: 'SearchAPIQuery' object has no attribute 'aggregate'`. Adding an `aggregate` expectedly breaks all the tests that use that method.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] Requests to `/files` dataset endpoint with non-existent dataset `pid` should return `404`
- [ ] Requests to `/files/count` dataset endpoint with non-existent dataset `pid` should return `404`