### PR TITLE
Fix cachetools.LRUCache DeprecationWarning

### DIFF
--- a/datagateway_api/src/datagateway_api/icat/lru_cache.py
+++ b/datagateway_api/src/datagateway_api/icat/lru_cache.py
@@ -1,6 +1,6 @@
 import logging
 
-from cachetools.lru import LRUCache
+from cachetools import LRUCache
 
 from datagateway_api.src.common.config import Config
 


### PR DESCRIPTION
This PR will close #321 

## Description
Fixes the `cachetools.LRUCache` `DeprecationWarning` (see issue description for example) that is printed to terminal when tests are ran.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] No `cachetools.LRUCache` `DeprecationWarning` should be printed to terminal when running the tests