### PR TITLE
Fix failing Nox tests session on Windows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -94,7 +94,9 @@ def tests(session):
     # Currently, only a pre-release exists for Poetry 1.2. Testing on the pre-release
     # version didn't fix the `2to3` issue when building Python ICAT, perhaps because
     # Python ICAT isn't built on the downgraded version for some reason?
-    session.run("poetry", "run", "pip", "uninstall", "-y", "setuptools")
-    session.run("poetry", "run", "pip", "install", "setuptools<58.0.0")
+    session.run("pip", "uninstall", "-y", "setuptools")
+    # Not using `poetry run` as it errors on Windows OS when a version with the '<'
+    # sign is specified for a package
+    session.run("pip", "install", "setuptools<58.0.0")
     session.run("poetry", "install", external=True)
     session.run("pytest", *args)


### PR DESCRIPTION
This PR will close #307 

## Description
Fixes the failing `nox` `tests` session on Windows.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] `nox` `tests` session should not fail
- [ ] The version of the installed `setuptools` should be `<58.0.0`