### PR TITLE
Add OpenAPI docs for Search API

### DIFF
--- a/datagateway_api/src/main.py
+++ b/datagateway_api/src/main.py
@@ -5,8 +5,7 @@ from flask import Flask
 from datagateway_api.src.api_start_utils import (
     create_api_endpoints,
     create_app_infrastructure,
-    create_openapi_endpoint,
-    openapi_config,
+    create_openapi_endpoints,
 )
 from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.logger_setup import setup_logger
@@ -16,10 +15,9 @@ log = logging.getLogger()
 log.info("Logging now setup")
 
 app = Flask(__name__)
-api, spec = create_app_infrastructure(app)
-create_api_endpoints(app, api, spec)
-openapi_config(spec)
-create_openapi_endpoint(app, spec)
+api, specs = create_app_infrastructure(app)
+create_api_endpoints(app, api, specs)
+create_openapi_endpoints(app, specs)
 
 if __name__ == "__main__":
     app.run(

--- a/datagateway_api/src/resources/search_api_endpoints.py
+++ b/datagateway_api/src/resources/search_api_endpoints.py
@@ -232,7 +232,35 @@ def get_number_count_files_endpoint(entity_name):
             log.debug("Filters: %s", filters)
             return get_files_count(entity_name, filters, pid)
 
-        # TODO - Add `get.__doc__`
+        get.__doc__ = f"""
+            ---
+            summary: Count {entity_name}s for the given Dataset
+            description: Return the count of {entity_name} objects for the given Dataset
+                object that would be retrieved given the filters provided
+            tags:
+                - Dataset
+            parameters:
+                - in: path
+                  required: true
+                  name: pid
+                  description: The pid of the entity to retrieve
+                  schema:
+                    oneOf:
+                      - type: string
+                - WHERE_FILTER
+            responses:
+                200:
+                    description: Success - The count of {entity_name} objects for the
+                        given Dataset object
+                    content:
+                        application/json:
+                            schema:
+                                type: integer
+                400:
+                    description: Bad request - Something was wrong with the request
+                404:
+                    description: No such record - Unable to find a record in ICAT
+            """
 
     CountFilesEndpoint.__name__ = entity_name
     return CountFilesEndpoint

--- a/datagateway_api/src/resources/search_api_endpoints.py
+++ b/datagateway_api/src/resources/search_api_endpoints.py
@@ -33,7 +33,30 @@ def get_search_endpoint(entity_name):
             log.debug("Filters: %s", filters)
             return get_search(entity_name, filters), 200
 
-        # TODO - Add `get.__doc__`
+        get.__doc__ = f"""
+            ---
+            summary: Get {entity_name}s
+            description: Retrieves a list of {entity_name} objects
+            tags:
+                - {entity_name}
+            parameters:
+                - FILTER
+            responses:
+                200:
+                    description: Success - returns {entity_name}s that satisfy the
+                        filter
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                  $ref:
+                                    '#/components/schemas/{entity_name}'
+                400:
+                    description: Bad request - Something was wrong with the request
+                404:
+                    description: No such record - Unable to find a record in ICAT
+            """
 
     Endpoint.__name__ = entity_name
     return Endpoint

--- a/datagateway_api/src/resources/search_api_endpoints.py
+++ b/datagateway_api/src/resources/search_api_endpoints.py
@@ -131,7 +131,27 @@ def get_number_count_endpoint(entity_name):
             log.debug("Filters: %s", filters)
             return get_count(entity_name, filters), 200
 
-        # TODO - Add `get.__doc__`
+        get.__doc__ = f"""
+            ---
+            summary: Count {entity_name}s
+            description: Return the count of the {entity_name} objects that would be
+                retrieved given the filters provided
+            tags:
+                - {entity_name}
+            parameters:
+                - WHERE_FILTER
+            responses:
+                200:
+                    description: Success - The count of the {entity_name} objects
+                    content:
+                        application/json:
+                            schema:
+                                type: integer
+                400:
+                    description: Bad request - Something was wrong with the request
+                404:
+                    description: No such record - Unable to find a record in ICAT
+            """
 
     CountEndpoint.__name__ = entity_name
     return CountEndpoint

--- a/datagateway_api/src/resources/search_api_endpoints.py
+++ b/datagateway_api/src/resources/search_api_endpoints.py
@@ -80,7 +80,33 @@ def get_single_endpoint(entity_name):
             log.debug("Filters: %s", filters)
             return get_with_pid(entity_name, pid, filters), 200
 
-        # TODO - Add `get.__doc__`
+        get.__doc__ = f"""
+            ---
+            summary: Find the {entity_name} matching the given pid
+            description: Retrieves a {entity_name} object with the matching pid
+            tags:
+                - {entity_name}
+            parameters:
+                - in: path
+                  required: true
+                  name: pid
+                  description: The pid of the entity to retrieve
+                  schema:
+                    oneOf:
+                      - type: string
+                - FILTER
+            responses:
+                200:
+                    description: Success - the matching {entity_name}
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/{entity_name}'
+                400:
+                    description: Bad request - Something was wrong with the request
+                404:
+                    description: No such record - Unable to find a record in ICAT
+            """
 
     EndpointWithID.__name__ = entity_name
     return EndpointWithID

--- a/datagateway_api/src/resources/search_api_endpoints.py
+++ b/datagateway_api/src/resources/search_api_endpoints.py
@@ -175,7 +175,38 @@ def get_files_endpoint(entity_name):
             log.debug("Filters: %s", filters)
             return get_files(entity_name, pid, filters), 200
 
-        # TODO - Add `get.__doc__`
+        get.__doc__ = f"""
+            ---
+            summary: Get {entity_name}s for the given Dataset
+            description: Retrieves a list of {entity_name} objects for a given Dataset
+                object
+            tags:
+                - Dataset
+            parameters:
+                - in: path
+                  required: true
+                  name: pid
+                  description: The pid of the entity to retrieve
+                  schema:
+                    oneOf:
+                      - type: string
+                - FILTER
+            responses:
+                200:
+                    description: Success - returns {entity_name}s for the given Dataset
+                        object that satisfy the filter
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                  $ref:
+                                    '#/components/schemas/{entity_name}'
+                400:
+                    description: Bad request - Something was wrong with the request
+                404:
+                    description: No such record - Unable to find a record in ICAT
+            """
 
     FilesEndpoint.__name__ = entity_name
     return FilesEndpoint

--- a/datagateway_api/src/swagger/datagateway_api/openapi.yaml
+++ b/datagateway_api/src/swagger/datagateway_api/openapi.yaml
@@ -1659,6 +1659,8 @@ components:
           type: string
         name:
           type: string
+        pid:
+          type: string
         startDate:
           format: datetime
           type: string
@@ -11013,19 +11015,5 @@ paths:
       summary: Ping API connection method
       tags:
       - Ping
-  /search-api/datasets:
-    get: {}
-  /search-api/datasets/{pid}: {}
-  /search-api/datasets/count: {}
-  /search-api/documents:
-    get: {}
-  /search-api/documents/{pid}: {}
-  /search-api/documents/count: {}
-  /search-api/instruments:
-    get: {}
-  /search-api/instruments/{pid}: {}
-  /search-api/instruments/count: {}
-  /search-api/datasets/{pid}/files: {}
-  /search-api/datasets/{pid}/files/count: {}
 security:
 - session_id: []

--- a/datagateway_api/src/swagger/initialise_spec.py
+++ b/datagateway_api/src/swagger/initialise_spec.py
@@ -1,7 +1,19 @@
 from datagateway_api.src.resources.entities.entity_map import create_entity_models
+from datagateway_api.src.search_api.models import (
+    Affiliation,
+    Dataset,
+    Document,
+    File,
+    Instrument,
+    Member,
+    Parameter,
+    Person,
+    Sample,
+    Technique,
+)
 
 
-def initialise_spec(spec):
+def initialise_datagateway_api_spec(spec):
     """
     Given a apispec spec object, will initialise it with the security scheme, models and
     parameters we use
@@ -270,6 +282,121 @@ def initialise_spec(spec):
                         },
                     ],
                 },
+            },
+        },
+    )
+
+
+def initialise_search_api_spec(spec):
+    """
+    Given a apispec spec object, will initialise it with the models and parameters we
+    use
+
+    :spec: ApiSpec: spec object to initialise
+    :return: void
+    """
+    panosc_models = [
+        Affiliation,
+        Dataset,
+        Document,
+        File,
+        Instrument,
+        Member,
+        Parameter,
+        Person,
+        Sample,
+        Technique,
+    ]
+    for panosc_model in panosc_models:
+        schema = panosc_model.schema(ref_template="#/components/schemas/{model}")[
+            "definitions"
+        ][panosc_model.__name__]
+
+        schema_name = panosc_model.__name__
+        spec.components.schema(schema_name, schema)
+
+    spec.components.parameter(
+        "FILTER",
+        "query",
+        {
+            "in": "query",
+            "name": "filter",
+            "description": "Apply filters to the query. The possible filters are:"
+            " where, include, limit and skip. Please modify the examples before"
+            " executing a request if you are having issues with the example values."
+            ' must be a JSON-encoded string (`{"where":{"something":"value"}}`).'
+            " See more details"
+            ' <a href="https://loopback.io/doc/en/lb3/Querying-data.html#using'
+            '-stringified-json-in-rest-queries">here</a>.',
+            "schema": {"type": "string"},
+            "examples": {
+                "where filter": {"value": {"where": {"title": {"eq": "dog"}}}},
+                "where filter with text operator": {
+                    "value": {"where": {"text": "dog"}},
+                },
+                "where filter with AND": {
+                    "value": {"where": {"and": [{"title": "dog"}, {"size": 10000}]}},
+                },
+                "where filter with OR": {
+                    "value": {"where": {"or": [{"title": "dog"}, {"size": 10000}]}},
+                },
+                "limit filter": {"value": {"limit": 10}},
+                "skip filter": {"value": {"skip": 5}},
+                "include filter": {"value": {"include": [{"relation": "datasets"}]}},
+                "include filter with scope": {
+                    "value": {
+                        "include": [
+                            {
+                                "relation": "datasets",
+                                "scope": {"where": {"title": "dog"}},
+                            },
+                        ],
+                    },
+                },
+                "all possible filters": {
+                    "value": {
+                        "where": {"title": {"neq": "dog"}},
+                        "include": [
+                            {
+                                "relation": "datasets",
+                                "scope": {"where": {"title": "dog"}},
+                            },
+                        ],
+                        "limit": 10,
+                        "skip": 5,
+                    },
+                },
+            },
+        },
+    )
+    spec.components.parameter(
+        "WHERE_FILTER",
+        "query",
+        {
+            "in": "query",
+            "name": "where",
+            "description": "Apply where filter to the query. The possible operators"
+            " are: eq, neq, and, or, gt, gte, lt, lte, between, inq, nin, like, nlike,"
+            " ilike, nilike and regexp. Please modify the examples before executing a "
+            "request if you are having issues with the example values. See more details"
+            ' <a href="https://loopback.io/doc/en/lb3/Where-filter.html">here</a>.',
+            "schema": {"type": "string"},
+            "examples": {
+                "eq": {"value": {"title": {"eq": "dog"}}},
+                "ne": {"value": {"title": {"neq": "dog"}}},
+                "and": {"value": [{"title": "dog"}, {"size": 10000}]},
+                "or": {"value": [{"title": "dog"}, {"size": 10000}]},
+                "gt": {"value": {"size": {"gt": 10000}}},
+                "gte": {"value": {"size": {"gte": 10000}}},
+                "lt": {"value": {"size": {"lt": 10000}}},
+                "lte": {"value": {"size": {"lte": 10000}}},
+                "between": {"value": {"size": {"between": [5000, 10000]}}},
+                "inq": {"value": {"size": {"inq": [5000, 10000, 15000]}}},
+                "nin": {"value": {"size": {"inq": [5000, 10000, 15000]}}},
+                "like": {"value": {"title": {"like": "dog"}}},
+                "nlike": {"value": {"title": {"nlike": "dog"}}},
+                "ilike": {"value": {"title": {"ilike": "Dog"}}},
+                "nilike": {"value": {"title": {"nilike": "Dog"}}},
             },
         },
     )

--- a/datagateway_api/src/swagger/search_api/openapi.yaml
+++ b/datagateway_api/src/swagger/search_api/openapi.yaml
@@ -1,0 +1,728 @@
+components:
+  parameters:
+    FILTER:
+      description: 'Apply filters to the query. The possible filters are: where, include,
+        limit and skip. Please modify the examples before executing a request if you
+        are having issues with the example values. must be a JSON-encoded string (`{"where":{"something":"value"}}`).
+        See more details <a href="https://loopback.io/doc/en/lb3/Querying-data.html#using-stringified-json-in-rest-queries">here</a>.'
+      examples:
+        all possible filters:
+          value:
+            include:
+            - relation: datasets
+              scope:
+                where:
+                  title: dog
+            limit: 10
+            skip: 5
+            where:
+              title:
+                neq: dog
+        include filter:
+          value:
+            include:
+            - relation: datasets
+        include filter with scope:
+          value:
+            include:
+            - relation: datasets
+              scope:
+                where:
+                  title: dog
+        limit filter:
+          value:
+            limit: 10
+        skip filter:
+          value:
+            skip: 5
+        where filter:
+          value:
+            where:
+              title:
+                eq: dog
+        where filter with AND:
+          value:
+            where:
+              and:
+              - title: dog
+              - size: 10000
+        where filter with OR:
+          value:
+            where:
+              or:
+              - title: dog
+              - size: 10000
+        where filter with text operator:
+          value:
+            where:
+              text: dog
+      in: query
+      name: filter
+      schema:
+        type: string
+    WHERE_FILTER:
+      description: 'Apply where filter to the query. The possible operators are: eq,
+        neq, and, or, gt, gte, lt, lte, between, inq, nin, like, nlike, ilike, nilike
+        and regexp. Please modify the examples before executing a request if you are
+        having issues with the example values. See more details <a href="https://loopback.io/doc/en/lb3/Where-filter.html">here</a>.'
+      examples:
+        and:
+          value:
+          - title: dog
+          - size: 10000
+        between:
+          value:
+            size:
+              between:
+              - 5000
+              - 10000
+        eq:
+          value:
+            title:
+              eq: dog
+        gt:
+          value:
+            size:
+              gt: 10000
+        gte:
+          value:
+            size:
+              gte: 10000
+        ilike:
+          value:
+            title:
+              ilike: Dog
+        inq:
+          value:
+            size:
+              inq:
+              - 5000
+              - 10000
+              - 15000
+        like:
+          value:
+            title:
+              like: dog
+        lt:
+          value:
+            size:
+              lt: 10000
+        lte:
+          value:
+            size:
+              lte: 10000
+        ne:
+          value:
+            title:
+              neq: dog
+        nilike:
+          value:
+            title:
+              nilike: Dog
+        nin:
+          value:
+            size:
+              inq:
+              - 5000
+              - 10000
+              - 15000
+        nlike:
+          value:
+            title:
+              nlike: dog
+        or:
+          value:
+          - title: dog
+          - size: 10000
+      in: query
+      name: where
+      schema:
+        type: string
+  schemas:
+    Affiliation:
+      description: Information about which facility a member is located at
+      properties:
+        address:
+          title: Address
+          type: string
+        city:
+          title: City
+          type: string
+        country:
+          title: Country
+          type: string
+        id:
+          title: Id
+          type: string
+        members:
+          default: []
+          items:
+            $ref: '#/components/schemas/Member'
+          title: Members
+          type: array
+        name:
+          title: Name
+          type: string
+      title: Affiliation
+      type: object
+    Dataset:
+      description: 'Information about an experimental run, including optional File,
+        Sample, Instrument
+
+        and Technique'
+      properties:
+        creationDate:
+          format: date-time
+          title: Creationdate
+          type: string
+        documents:
+          default: []
+          items:
+            $ref: '#/components/schemas/Document'
+          title: Documents
+          type: array
+        files:
+          default: []
+          items:
+            $ref: '#/components/schemas/File'
+          title: Files
+          type: array
+        instrument:
+          $ref: '#/components/schemas/Instrument'
+        isPublic:
+          title: Ispublic
+          type: boolean
+        parameters:
+          default: []
+          items:
+            $ref: '#/components/schemas/Parameter'
+          title: Parameters
+          type: array
+        pid:
+          title: Pid
+          type: string
+        samples:
+          default: []
+          items:
+            $ref: '#/components/schemas/Sample'
+          title: Samples
+          type: array
+        size:
+          title: Size
+          type: integer
+        techniques:
+          default: []
+          items:
+            $ref: '#/components/schemas/Technique'
+          title: Techniques
+          type: array
+        title:
+          title: Title
+          type: string
+      required:
+      - pid
+      - title
+      - isPublic
+      - creationDate
+      title: Dataset
+      type: object
+    Document:
+      description: Proposal which includes the dataset or published paper which references
+        the dataset
+      properties:
+        datasets:
+          default: []
+          items:
+            $ref: '#/components/schemas/Dataset'
+          title: Datasets
+          type: array
+        doi:
+          title: Doi
+          type: string
+        endDate:
+          format: date-time
+          title: Enddate
+          type: string
+        isPublic:
+          title: Ispublic
+          type: boolean
+        keywords:
+          default: []
+          items:
+            type: string
+          title: Keywords
+          type: array
+        license:
+          title: License
+          type: string
+        members:
+          default: []
+          items:
+            $ref: '#/components/schemas/Member'
+          title: Members
+          type: array
+        parameters:
+          default: []
+          items:
+            $ref: '#/components/schemas/Parameter'
+          title: Parameters
+          type: array
+        pid:
+          title: Pid
+          type: string
+        releaseDate:
+          format: date-time
+          title: Releasedate
+          type: string
+        startDate:
+          format: date-time
+          title: Startdate
+          type: string
+        summary:
+          title: Summary
+          type: string
+        title:
+          title: Title
+          type: string
+        type:
+          title: Type
+          type: string
+      required:
+      - pid
+      - isPublic
+      - type
+      - title
+      title: Document
+      type: object
+    File:
+      description: Name of file and optionally location
+      properties:
+        dataset:
+          $ref: '#/components/schemas/Dataset'
+        id:
+          title: Id
+          type: string
+        name:
+          title: Name
+          type: string
+        path:
+          title: Path
+          type: string
+        size:
+          title: Size
+          type: integer
+      required:
+      - id
+      - name
+      title: File
+      type: object
+    Instrument:
+      description: Beam line where experiment took place
+      properties:
+        datasets:
+          default: []
+          items:
+            $ref: '#/components/schemas/Dataset'
+          title: Datasets
+          type: array
+        facility:
+          title: Facility
+          type: string
+        name:
+          title: Name
+          type: string
+        pid:
+          title: Pid
+          type: string
+      required:
+      - pid
+      - name
+      - facility
+      title: Instrument
+      type: object
+    Member:
+      description: Proposal team member or paper co-author
+      properties:
+        affiliation:
+          $ref: '#/components/schemas/Affiliation'
+        document:
+          $ref: '#/components/schemas/Document'
+        id:
+          title: Id
+          type: string
+        person:
+          $ref: '#/components/schemas/Person'
+        role:
+          title: Role
+          type: string
+      required:
+      - id
+      title: Member
+      type: object
+    Parameter:
+      description: 'Scalar measurement with value and units.
+
+        Note: a parameter is either related to a dataset or a document, but not both.'
+      properties:
+        dataset:
+          $ref: '#/components/schemas/Dataset'
+        document:
+          $ref: '#/components/schemas/Document'
+        id:
+          title: Id
+          type: string
+        name:
+          title: Name
+          type: string
+        unit:
+          title: Unit
+          type: string
+        value:
+          anyOf:
+          - type: number
+          - type: integer
+          - type: string
+          title: Value
+      required:
+      - id
+      - name
+      - value
+      title: Parameter
+      type: object
+    Person:
+      description: Human who carried out experiment
+      properties:
+        firstName:
+          title: Firstname
+          type: string
+        fullName:
+          title: Fullname
+          type: string
+        id:
+          title: Id
+          type: string
+        lastName:
+          title: Lastname
+          type: string
+        members:
+          default: []
+          items:
+            $ref: '#/components/schemas/Member'
+          title: Members
+          type: array
+        orcid:
+          title: Orcid
+          type: string
+        researcherId:
+          title: Researcherid
+          type: string
+      required:
+      - id
+      - fullName
+      title: Person
+      type: object
+    Sample:
+      description: Extract of material used in the experiment
+      properties:
+        datasets:
+          default: []
+          items:
+            $ref: '#/components/schemas/Dataset'
+          title: Datasets
+          type: array
+        description:
+          title: Description
+          type: string
+        name:
+          title: Name
+          type: string
+        pid:
+          title: Pid
+          type: string
+      required:
+      - name
+      - pid
+      title: Sample
+      type: object
+    Technique:
+      description: Common name of scientific method used
+      properties:
+        datasets:
+          default: []
+          items:
+            $ref: '#/components/schemas/Dataset'
+          title: Datasets
+          type: array
+        name:
+          title: Name
+          type: string
+        pid:
+          title: Pid
+          type: string
+      required:
+      - pid
+      - name
+      title: Technique
+      type: object
+info:
+  title: Search API
+  version: '1.0'
+openapi: 3.0.3
+paths:
+  /search-api/datasets:
+    get:
+      description: Retrieves a list of Dataset objects
+      parameters:
+      - $ref: '#/components/parameters/FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Dataset'
+                type: array
+          description: Success - returns Datasets that satisfy the filter
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Get Datasets
+      tags:
+      - Dataset
+  /search-api/datasets/{pid}:
+    get:
+      description: Retrieves a Dataset object with the matching pid
+      parameters:
+      - description: The pid of the entity to retrieve
+        in: path
+        name: pid
+        required: true
+        schema:
+          oneOf:
+          - type: string
+      - $ref: '#/components/parameters/FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dataset'
+          description: Success - the matching Dataset
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Find the Dataset matching the given pid
+      tags:
+      - Dataset
+  /search-api/datasets/count:
+    get:
+      description: Return the count of the Dataset objects that would be retrieved
+        given the filters provided
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: integer
+          description: Success - The count of the Dataset objects
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Count Datasets
+      tags:
+      - Dataset
+  /search-api/documents:
+    get:
+      description: Retrieves a list of Document objects
+      parameters:
+      - $ref: '#/components/parameters/FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Document'
+                type: array
+          description: Success - returns Documents that satisfy the filter
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Get Documents
+      tags:
+      - Document
+  /search-api/documents/{pid}:
+    get:
+      description: Retrieves a Document object with the matching pid
+      parameters:
+      - description: The pid of the entity to retrieve
+        in: path
+        name: pid
+        required: true
+        schema:
+          oneOf:
+          - type: string
+      - $ref: '#/components/parameters/FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+          description: Success - the matching Document
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Find the Document matching the given pid
+      tags:
+      - Document
+  /search-api/documents/count:
+    get:
+      description: Return the count of the Document objects that would be retrieved
+        given the filters provided
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: integer
+          description: Success - The count of the Document objects
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Count Documents
+      tags:
+      - Document
+  /search-api/instruments:
+    get:
+      description: Retrieves a list of Instrument objects
+      parameters:
+      - $ref: '#/components/parameters/FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/Instrument'
+                type: array
+          description: Success - returns Instruments that satisfy the filter
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Get Instruments
+      tags:
+      - Instrument
+  /search-api/instruments/{pid}:
+    get:
+      description: Retrieves a Instrument object with the matching pid
+      parameters:
+      - description: The pid of the entity to retrieve
+        in: path
+        name: pid
+        required: true
+        schema:
+          oneOf:
+          - type: string
+      - $ref: '#/components/parameters/FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Instrument'
+          description: Success - the matching Instrument
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Find the Instrument matching the given pid
+      tags:
+      - Instrument
+  /search-api/instruments/count:
+    get:
+      description: Return the count of the Instrument objects that would be retrieved
+        given the filters provided
+      parameters:
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: integer
+          description: Success - The count of the Instrument objects
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Count Instruments
+      tags:
+      - Instrument
+  /search-api/datasets/{pid}/files:
+    get:
+      description: Retrieves a list of File objects for a given Dataset object
+      parameters:
+      - description: The pid of the entity to retrieve
+        in: path
+        name: pid
+        required: true
+        schema:
+          oneOf:
+          - type: string
+      - $ref: '#/components/parameters/FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/File'
+                type: array
+          description: Success - returns Files for the given Dataset object that satisfy
+            the filter
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Get Files for the given Dataset
+      tags:
+      - Dataset
+  /search-api/datasets/{pid}/files/count:
+    get:
+      description: Return the count of File objects for the given Dataset object that
+        would be retrieved given the filters provided
+      parameters:
+      - description: The pid of the entity to retrieve
+        in: path
+        name: pid
+        required: true
+        schema:
+          oneOf:
+          - type: string
+      - $ref: '#/components/parameters/WHERE_FILTER'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: integer
+          description: Success - The count of File objects for the given Dataset object
+        '400':
+          description: Bad request - Something was wrong with the request
+        '404':
+          description: No such record - Unable to find a record in ICAT
+      summary: Count Files for the given Dataset
+      tags:
+      - Dataset


### PR DESCRIPTION
Since issue #281 states that the OpenAPI docs for DG API should be updated but this PR only adds OpenAPI docs for the Search API, I think that issue should stay opened.

## Description
Adds OpenAPI docs for the Search API and implements two separate OpenAPI endpoints - one for DG API and another for Search API. If the extension for the DG API is `/datagateway-api` and for Search API is `/search-api` then that is where the Swagger UIs can be accessed.

When looking at the Swagger UI, you will notice that the endpoints are prefixed with the API's extension. Ideally, they should not be prefixed but I could not fix this.

I was also faced with an error when I tried to run DG API on its own so that I can test everything works as expected. This issue will be fixed as part of https://github.com/ral-facilities/datagateway-api/issues/345

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] Swagger UI for DG API loads and requests can be sent
- [ ] Swagger UI for Search API loads and requests can be sent