### PR TITLE
ci: remove existing mysql install on GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Change hostname to localhost
         run: sudo hostname -b localhost
 
+      # Remove existing MySQL installation so it doesn't interfere with GitHub Actions
+      - name: Remove existing mysql
+        run: |
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apt-get remove --purge "mysql*"
+          sudo rm -rf /var/lib/mysql* /etc/mysql
+
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook
         run: |
@@ -214,6 +221,13 @@ jobs:
       # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
       - name: Change hostname to localhost
         run: sudo hostname -b localhost
+
+      # Remove existing MySQL installation so it doesn't interfere with GitHub Actions
+      - name: Remove existing mysql
+        run: |
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apt-get remove --purge "mysql*"
+          sudo rm -rf /var/lib/mysql* /etc/mysql
 
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook


### PR DESCRIPTION
## Description
This PR is the result of merging https://github.com/icatproject-contrib/icat-ansible/pull/78 on ICAT Ansible. That PR fixes some bugs relating to the installation of mariadb. For GitHub Actions, the existing installation of mysql must be removed so it doesn't interfere with the one installed by ICAT Ansible. This PR just adds that step in.

## Testing Instructions
Just check that CI passes.

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
