### PR TITLE
Add Python 3.10 to CI Testing

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     name: Python ${{ matrix.python-version }} Build & Tests
     steps:
       - name: Add apt repo

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -103,6 +103,14 @@ jobs:
       - name: Install older setuptools
         run: poetry run pip install 'setuptools<58.0.0'
 
+      # This command is a workaround for getting Poetry working with Python 3.10. An
+      # fix is made in Poetry 1.2.0a2 but there is currently no official release for
+      # Poetry 1.2 and am apprehensive to moving to a pre-release. Disabling the
+      # experimental installer is a workaround for Poetry 1.1.x
+      # See https://github.com/python-poetry/poetry/issues/4210 for more details
+      - name: Disable Poetry's experimental new installer
+        run: poetry config experimental.new-installer false
+
       - name: Install dependencies
         run: poetry install
 

--- a/README.md
+++ b/README.md
@@ -386,6 +386,10 @@ poetry remove python-icat
 poetry add python-icat=0.21.0
 ```
 
+If using Python 3.10, please use Payara 5 on the ICAT stack which the API is being
+pointed at. There is a known issue when making HTTPS connections to Payara (via Python
+ICAT).
+
 
 ## DataGateway API Authentication
 Each request requires a valid session ID to be provided in the Authorization header.
@@ -427,8 +431,8 @@ your test environment, using `config.json.example` as a reference. The tests req
 connection to an instance of ICAT, so set the rest of the config as needed.
 
 By default, this will execute the repo's tests in
-Python 3.6, 3.7 and 3.8. For most cases, running the tests in a single Python version
-will be sufficient:
+Python 3.6, 3.7, 3.8, 3.9 and 3.10. For most cases, running the tests in a single Python
+version will be sufficient:
 
 ```bash
 nox -p 3.6 -s tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,7 +82,7 @@ def safety(session):
             session.log("Error: The temporary requirements file could not be closed")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"], reuse_venv=True)
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"], reuse_venv=True)
 def tests(session):
     args = session.posargs
     # Installing setuptools that will work with `2to3` which is used when building

--- a/poetry.lock
+++ b/poetry.lock
@@ -741,7 +741,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pycparser"
-version = "2.20"
+version = "2.21"
 description = "C parser in Python"
 category = "dev"
 optional = false
@@ -1737,8 +1737,8 @@ pycodestyle = [
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
 pycparser = [
-    {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
-    {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pydantic = [
     {file = "pydantic-1.8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:05ddfd37c1720c392f4e0d43c484217b7521558302e7069ce8d318438d297739"},


### PR DESCRIPTION
## Description
This PR adds Python 3.10 to be tested on GitHub Actions (and the Nox session used on the CI). To do this, I've bumped the version of `pycparser` as I was seeing some issues with it before and I disabled Poetry's experimental installer. I've added a note in the CI build file that explains the reasoning for that. Hopefully this workaround can be removed when an official release of Poetry 1.2.x has been made.

No version bump as this just impacts CI.

## Testing Instructions
Check the CI passes

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?