### PR TITLE
500 Internal server error when running DG API on its own and sending Investigations request

### DIFF
--- a/datagateway_api/src/common/filter_order_handler.py
+++ b/datagateway_api/src/common/filter_order_handler.py
@@ -53,8 +53,10 @@ class FilterOrderHandler(object):
             # Using `type()` because we only want the Python ICAT version, don't want
             # the code to catch objects that inherit from the class e.g.
             # `SearchAPIIncludeFilter`
-            if type(query_filter) is PythonICATIncludeFilter and isinstance(
-                query, SearchAPIQuery,
+            if (
+                Config.config.search_api
+                and type(query_filter) is PythonICATIncludeFilter
+                and isinstance(query, SearchAPIQuery)
             ):
                 query = query.icat_query.query
             query_filter.apply_filter(query)


### PR DESCRIPTION
This PR will close #359 

## Description
The requests that the DataGateway Dataview plugin is sending to `/investigations` are all returning `500 INTERNAL SERVER ERROR` so the changes in this PR fix this.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] `/investigations` requests are no longer returning `500 INTERNAL SERVER ERROR`