### PR TITLE
This fixes the problem with limit when it is not a number

### DIFF
--- a/datagateway_api/src/search_api/filters.py
+++ b/datagateway_api/src/search_api/filters.py
@@ -148,7 +148,7 @@ class SearchAPIWhereFilter(PythonICATWhereFilter):
 
 class SearchAPISkipFilter(PythonICATSkipFilter):
     def __init__(self, skip_value):
-        super().__init__(skip_value, filter_use="search_api")
+        super().__init__(int(skip_value), filter_use="search_api")
 
     def apply_filter(self, query):
         return super().apply_filter(query.icat_query.query)
@@ -156,7 +156,7 @@ class SearchAPISkipFilter(PythonICATSkipFilter):
 
 class SearchAPILimitFilter(PythonICATLimitFilter):
     def __init__(self, limit_value):
-        super().__init__(limit_value)
+        super().__init__(int(limit_value))
 
     def apply_filter(self, query):
         return super().apply_filter(query.icat_query.query)

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -58,7 +58,7 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
                     )
                 elif filter_name == "limit":
                     log.info("limit JSON object found")
-                    query_filters.append(SearchAPILimitFilter(int(filter_input)))
+                    query_filters.append(SearchAPILimitFilter(filter_input))
                 elif filter_name == "skip":
                     log.info("skip JSON object found")
                     query_filters.append(SearchAPISkipFilter(filter_input))

--- a/datagateway_api/src/search_api/query_filter_factory.py
+++ b/datagateway_api/src/search_api/query_filter_factory.py
@@ -58,7 +58,7 @@ class SearchAPIQueryFilterFactory(QueryFilterFactory):
                     )
                 elif filter_name == "limit":
                     log.info("limit JSON object found")
-                    query_filters.append(SearchAPILimitFilter(filter_input))
+                    query_filters.append(SearchAPILimitFilter(int(filter_input)))
                 elif filter_name == "skip":
                     log.info("skip JSON object found")
                     query_filters.append(SearchAPISkipFilter(filter_input))

--- a/test/search_api/filters/test_search_api_limit_filter.py
+++ b/test/search_api/filters/test_search_api_limit_filter.py
@@ -24,7 +24,11 @@ class TestSearchAPILimitFilter:
 
     @pytest.mark.parametrize(
         "limit_value",
-        [pytest.param(-50, id="extreme invalid"), pytest.param(-1, id="boundary"), pytest.param("Nan", id="Nan string")],
+        [
+            pytest.param(-50, id="extreme invalid"),
+            pytest.param(-1, id="boundary"),
+            pytest.param("Nan", id="Nan string"),
+        ],
     )
     def test_invalid_limit_value(self, limit_value):
         with pytest.raises((FilterError, Exception)):

--- a/test/search_api/filters/test_search_api_limit_filter.py
+++ b/test/search_api/filters/test_search_api_limit_filter.py
@@ -11,18 +11,21 @@ class TestSearchAPILimitFilter:
             pytest.param(10, id="typical"),
             pytest.param(0, id="low boundary"),
             pytest.param(9999, id="high boundary"),
+            pytest.param("10", id="string parameter typical"),
+            pytest.param("0", id="string parameter low boundary"),
+            pytest.param("9999", id="string parameter high boundary"),
         ],
     )
     def test_valid_limit_value(self, limit_value, search_api_query_document):
         test_filter = SearchAPILimitFilter(limit_value)
         test_filter.apply_filter(search_api_query_document)
 
-        assert search_api_query_document.icat_query.query.limit == (0, limit_value)
+        assert search_api_query_document.icat_query.query.limit == (0, int(limit_value))
 
     @pytest.mark.parametrize(
         "limit_value",
-        [pytest.param(-50, id="extreme invalid"), pytest.param(-1, id="boundary")],
+        [pytest.param(-50, id="extreme invalid"), pytest.param(-1, id="boundary"), pytest.param("Nan", id="Nan string")],
     )
     def test_invalid_limit_value(self, limit_value):
-        with pytest.raises(FilterError):
+        with pytest.raises((FilterError, Exception)):
             SearchAPILimitFilter(limit_value)

--- a/test/search_api/filters/test_search_api_limit_filter.py
+++ b/test/search_api/filters/test_search_api_limit_filter.py
@@ -31,5 +31,5 @@ class TestSearchAPILimitFilter:
         ],
     )
     def test_invalid_limit_value(self, limit_value):
-        with pytest.raises((FilterError, Exception)):
+        with pytest.raises((FilterError, ValueError)):
             SearchAPILimitFilter(limit_value)

--- a/test/search_api/filters/test_search_api_skip_filter.py
+++ b/test/search_api/filters/test_search_api_skip_filter.py
@@ -8,14 +8,14 @@ from datagateway_api.src.search_api.filters import SearchAPISkipFilter
 
 class TestSearchAPISkipFilter:
     @pytest.mark.parametrize(
-        "skip_value", [pytest.param(10, id="typical"), pytest.param(0, id="boundary")],
+        "skip_value", [pytest.param(10, id="typical"), pytest.param(0, id="boundary"),pytest.param("10", id="string format typical"), pytest.param("0", id="string format boundary")],
     )
     def test_valid_skip_value(self, search_api_query_document, skip_value):
         test_filter = SearchAPISkipFilter(skip_value)
         test_filter.apply_filter(search_api_query_document)
 
         assert search_api_query_document.icat_query.query.limit == (
-            skip_value,
+            int(skip_value),
             get_icat_properties(
                 Config.config.search_api.icat_url,
                 Config.config.search_api.icat_check_cert,
@@ -24,8 +24,8 @@ class TestSearchAPISkipFilter:
 
     @pytest.mark.parametrize(
         "skip_value",
-        [pytest.param(-375, id="extreme invalid"), pytest.param(-1, id="boundary")],
+        [pytest.param(-375, id="extreme invalid"), pytest.param(-1, id="boundary"), pytest.param("Nan", id="Nan string")],
     )
     def test_invalid_skip_value(self, skip_value):
-        with pytest.raises(FilterError):
+        with pytest.raises((FilterError, Exception)):
             SearchAPISkipFilter(skip_value)

--- a/test/search_api/filters/test_search_api_skip_filter.py
+++ b/test/search_api/filters/test_search_api_skip_filter.py
@@ -8,7 +8,13 @@ from datagateway_api.src.search_api.filters import SearchAPISkipFilter
 
 class TestSearchAPISkipFilter:
     @pytest.mark.parametrize(
-        "skip_value", [pytest.param(10, id="typical"), pytest.param(0, id="boundary"),pytest.param("10", id="string format typical"), pytest.param("0", id="string format boundary")],
+        "skip_value",
+        [
+            pytest.param(10, id="typical"),
+            pytest.param(0, id="boundary"),
+            pytest.param("10", id="string format typical"),
+            pytest.param("0", id="string format boundary"),
+        ],
     )
     def test_valid_skip_value(self, search_api_query_document, skip_value):
         test_filter = SearchAPISkipFilter(skip_value)
@@ -24,7 +30,11 @@ class TestSearchAPISkipFilter:
 
     @pytest.mark.parametrize(
         "skip_value",
-        [pytest.param(-375, id="extreme invalid"), pytest.param(-1, id="boundary"), pytest.param("Nan", id="Nan string")],
+        [
+            pytest.param(-375, id="extreme invalid"),
+            pytest.param(-1, id="boundary"),
+            pytest.param("Nan", id="Nan string"),
+        ],
     )
     def test_invalid_skip_value(self, skip_value):
         with pytest.raises((FilterError, Exception)):

--- a/test/search_api/filters/test_search_api_skip_filter.py
+++ b/test/search_api/filters/test_search_api_skip_filter.py
@@ -37,5 +37,5 @@ class TestSearchAPISkipFilter:
         ],
     )
     def test_invalid_skip_value(self, skip_value):
-        with pytest.raises((FilterError, Exception)):
+        with pytest.raises((FilterError, ValueError)):
             SearchAPISkipFilter(skip_value)

--- a/test/search_api/test_search_api_query_filter_factory.py
+++ b/test/search_api/test_search_api_query_filter_factory.py
@@ -1879,6 +1879,7 @@ class TestSearchAPIQueryFilterFactory:
         [
             pytest.param({"filter": {"limit": 0}}, 0, id="Limit 0 values"),
             pytest.param({"filter": {"limit": 50}}, 50, id="Limit 50 values"),
+            pytest.param({"filter": {"limit": "25"}}, 25, id="Limit 25 values"),
         ],
     )
     def test_valid_limit_filter(self, test_request_filter, expected_limit_value):


### PR DESCRIPTION
This PR will close #363 

## Description
Enter a description of the changes here

## Testing Instructions
Both should work:
```
/search-api/datasets?filter={"limit":"3"}
/search-api/datasets?filter={"limit":3}
```

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}


