### PR TITLE
Create Actions job for uploading container image to Harbor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - k8s-deployment
 jobs:
   tests:
     runs-on: ubuntu-20.04
@@ -329,3 +329,10 @@ jobs:
       # different to SciGateway preprod
       - name: Diff SQL dumps
         run: diff -s ~/generator_script_dump_main.sql ~/generator_script_dump_1.sql
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -331,6 +331,9 @@ jobs:
         run: diff -s ~/generator_script_dump_main.sql ~/generator_script_dump_1.sql
 
   docker:
+    # This job triggers only if all the other jobs succeed and does different things depending on the context.
+    # The job builds the Docker image in all cases and also pushes the image to Harbor only if something is
+    # pushed to the k8s-deployment branch.
     needs: [tests, linting, formatting, safety, generator-script-testing]
     name: Docker
     runs-on: ubuntu-20.04
@@ -351,10 +354,12 @@ jobs:
       with:
         images: harbor.stfc.ac.uk/datagateway/datagateway-api
 
+    # TODO - Change github.ref to refs/heads/main before merging k8s-deployment into main
     - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
       uses: docker/build-push-action@v2
       with:
         context: .
+        # TODO - Change github.ref to refs/heads/main before merging k8s-deployment into main
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -351,10 +351,10 @@ jobs:
       with:
         images: harbor.stfc.ac.uk/datagateway/datagateway-api
 
-    - name: Build Docker image
+    - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
       uses: docker/build-push-action@v2
       with:
         context: .
-        push: false
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/k8s-deployment' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -350,3 +350,11 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: harbor.stfc.ac.uk/datagateway/datagateway-api
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: false
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -344,3 +344,9 @@ jobs:
         registry: harbor.stfc.ac.uk/datagateway
         username: ${{ secrets.HARBOR_USERNAME }}
         password: ${{ secrets.HARBOR_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: harbor.stfc.ac.uk/datagateway/datagateway-api

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    # TODO - Change this to main before merging k8s-deployment into main
     branches:
       - k8s-deployment
 jobs:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -331,6 +331,7 @@ jobs:
         run: diff -s ~/generator_script_dump_main.sql ~/generator_script_dump_1.sql
 
   docker:
+    needs: [tests, linting, formatting, safety, generator-script-testing]
     name: Docker
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -337,3 +337,10 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
+
+    - name: Login to Harbor
+      uses: docker/login-action@v1
+      with:
+        registry: harbor.stfc.ac.uk/datagateway
+        username: ${{ secrets.HARBOR_USERNAME }}
+        password: ${{ secrets.HARBOR_TOKEN }}


### PR DESCRIPTION
This PR will close #355 

## Description
The `docker` job introduced in this PR triggers only if all the other jobs in the CI workflow succeed and the things that it does depend on the context. It has been configured to always build the Docker image (not only on pushes to the `k8s-deployment`) but only push the image to Harbor if something is pushed to the `k8s-deployment` branch. The former allows to verify whether the Docker image is successfully building during PRs whereas the latter ensures that the image is not pushed during PRs as the proposed changes may be rejected in the end.

I have added TODOs to remind us to change the references of `k8s-deployment` branch to `main` in the CI workflow file once the `k8s-deployment` branch has been merged into `main`.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage