### PR TITLE
feat: Add warning for no api

### DIFF
--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -192,7 +192,8 @@ class APIConfig(BaseModel):
 
                 if "datagateway_api" not in data and "search_api" not in data:
                     log.warning(
-                        "   WARNING: There is no API specified in the configuration file"
+                        "   WARNING: There is no API specified in the "
+                        "configuration file",
                     )
 
                 return cls(**data)

--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -189,6 +189,12 @@ class APIConfig(BaseModel):
         try:
             with open(path, encoding="utf-8") as target:
                 data = json.load(target)
+
+                if "datagateway_api" not in data and "search_api" not in data:
+                    log.warning(
+                        "   WARNING: There is no API specified in the configuration file"
+                    )
+
                 return cls(**data)
         except (IOError, ValidationError) as error:
             sys.exit(f"An error occurred while trying to load the config data: {error}")


### PR DESCRIPTION
This PR will close #380 

## Description
Added a check to the configuration file loading function that outputs a warning if it cannot find a section for datagateway or search api in the config file

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
Connect to #380 
