### PR TITLE
Creation of related entities attempted when not specified to be included

### DIFF
--- a/datagateway_api/src/search_api/models.py
+++ b/datagateway_api/src/search_api/models.py
@@ -111,6 +111,19 @@ class PaNOSCAttribute(ABC, BaseModel):
                 # we have to get hold of its class definition and call its `from_icat`
                 # method to create an instance of itself with the ICAT data provided.
                 # Doing this allows for recursion.
+
+                if entity_field_alias not in [
+                    required_related_field.split(".")[0]
+                    for required_related_field in required_related_fields
+                ]:
+                    # Before proceeding, check if the related entity really needs to be created.
+                    # Do not attempt to create the related entity if ICAT data for it is available
+                    # but the entity has not been specified to be included. In such cases, the ICAT
+                    # data is likely available because the data for another entity field is
+                    # retrieved via that ICAT entity. We do not want to return data for related
+                    # entities unless explicitly specified to be included by the user.
+                    continue
+
                 data = (
                     [field_value] if not isinstance(field_value, list) else field_value
                 )

--- a/test/search_api/test_models.py
+++ b/test/search_api/test_models.py
@@ -411,8 +411,6 @@ class TestModels:
         expected_entity_data["pid"] = f"pid:{INVESTIGATION_ICAT_DATA['id']}"
         expected_entity_data["doi"] = None
         expected_entity_data["datasets"] = [DATASET_PANOSC_DATA, DATASET_PANOSC_DATA]
-        expected_entity_data["members"] = [MEMBER_PANOSC_DATA]
-        expected_entity_data["parameters"] = [PARAMETER_PANOSC_DATA]
 
         icat_data = INVESTIGATION_ICAT_DATA.copy()
         icat_data["doi"] = None
@@ -434,7 +432,6 @@ class TestModels:
 
     def test_from_icat_file_entity_with_data_for_all_related_entities(self):
         expected_entity_data = FILE_PANOSC_DATA.copy()
-        expected_entity_data["dataset"] = DATASET_PANOSC_DATA
 
         icat_data = DATAFILE_ICAT_DATA.copy()
         icat_data["dataset"] = DATASET_ICAT_DATA


### PR DESCRIPTION
This PR will close #387 

## Description
When the Search API sees data for related entities in the ICAT data response, it attempts to create corresponding Search API-related entities even if they are not specified to be included. The changes in this PR stop the creation of related entities if ICAT data for them is available but the entities have not been specified to be included.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

## Agile Board Tracking
Connect to #387 