### PR TITLE
ci: Main branch uses yaml config not json

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -303,7 +303,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Create config.yaml
-        run: cd /home/runner/work/datagateway-api/datagateway-api; cp datagateway_api/config.json.example datagateway_api/config.json
+        run: cd /home/runner/work/datagateway-api/datagateway-api; cp datagateway_api/config.yaml.example datagateway_api/config.yaml
       - name: Create search_api_mapping.json
         run: cd /home/runner/work/datagateway-api/datagateway-api; cp datagateway_api/search_api_mapping.json.example datagateway_api/search_api_mapping.json
 


### PR DESCRIPTION
This PR will close #{issue number}

## Description
Fix the issue that icat generator workflow fails because it requires a json file for the main branch

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
Connect to #{issue number}
