### PR TITLE
fix: add triggers for later stages of consistency test

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -305,8 +305,14 @@ jobs:
       # Regenerate table structure of icatdb
       - name: Reinstall ICAT Server
         run: cd /home/runner/install/icat.server; ./setup -vv install
+
+
       - name: Add ICAT 5 triggers
-        run: cd /home/runner/install/icat.server; mysql -ppw -uroot icatdb < create_triggers_mysql_5_0.sql
+        run: cd /home/runner/install/icat.server; mysql -picatdbuserpw -uicatdbuser -D icatdb < create_triggers_mysql_5_0.sql
+
+      - name: tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() }}
 
       - name: Add (new) dummy data to icatdb
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -266,6 +266,9 @@ jobs:
           sudo apt-get remove --purge "mysql*"
           sudo rm -rf /var/lib/mysql* /etc/mysql
 
+      - name: tmate session
+        uses: mxschmitt/action-tmate@v3
+
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook
         run: |
@@ -306,13 +309,8 @@ jobs:
       - name: Reinstall ICAT Server
         run: cd /home/runner/install/icat.server; ./setup -vv install
 
-
       - name: Add ICAT 5 triggers
         run: cd /home/runner/install/icat.server; mysql -picatdbuserpw -uicatdbuser -D icatdb < create_triggers_mysql_5_0.sql
-
-      - name: tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
 
       - name: Add (new) dummy data to icatdb
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -306,7 +306,7 @@ jobs:
       - name: Reinstall ICAT Server
         run: cd /home/runner/install/icat.server; ./setup -vv install
       - name: Add ICAT 5 triggers
-        run: cd /home/runner/install/icat.server; mysql -picatdbuserpw -uicatdbuser icatdb < create_triggers_mysql_5_0.sql
+        run: cd /home/runner/install/icat.server; mysql -ppw -uroot icatdb < create_triggers_mysql_5_0.sql
 
       - name: Add (new) dummy data to icatdb
         run: |
@@ -329,7 +329,7 @@ jobs:
       - name: Reinstall ICAT Server
         run: cd /home/runner/install/icat.server; ./setup -vv install
       - name: Add ICAT 5 triggers
-        run: cd /home/runner/install/icat.server; mysql -picatdbuserpw -uicatdbuser icatdb < create_triggers_mysql_5_0.sql
+        run: cd /home/runner/install/icat.server; mysql -ppw -uroot icatdb < create_triggers_mysql_5_0.sql
 
       - name: Checkout DataGateway API (default branch)
         uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -266,9 +266,6 @@ jobs:
           sudo apt-get remove --purge "mysql*"
           sudo rm -rf /var/lib/mysql* /etc/mysql
 
-      - name: tmate session
-        uses: mxschmitt/action-tmate@v3
-
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook
         run: |
@@ -310,7 +307,7 @@ jobs:
         run: cd /home/runner/install/icat.server; ./setup -vv install
 
       - name: Add ICAT 5 triggers
-        run: cd /home/runner/install/icat.server; mysql -picatdbuserpw -uicatdbuser -D icatdb < create_triggers_mysql_5_0.sql
+        run: cd /home/runner/install/icat.server; sudo mysql -uroot -D icatdb < create_triggers_mysql_5_0.sql
 
       - name: Add (new) dummy data to icatdb
         run: |
@@ -324,6 +321,10 @@ jobs:
       - name: Diff SQL dumps
         run: diff -s ~/generator_script_dump_1.sql ~/generator_script_dump_2.sql
 
+      - name: tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() }}
+
       # Drop and re-create icatdb to remove generated data
       - name: Drop icatdb
         run: mysql -picatdbuserpw -uicatdbuser -e 'DROP DATABASE icatdb;'
@@ -333,7 +334,7 @@ jobs:
       - name: Reinstall ICAT Server
         run: cd /home/runner/install/icat.server; ./setup -vv install
       - name: Add ICAT 5 triggers
-        run: cd /home/runner/install/icat.server; mysql -ppw -uroot icatdb < create_triggers_mysql_5_0.sql
+        run: cd /home/runner/install/icat.server; sudo mysql -uroot -D icatdb < create_triggers_mysql_5_0.sql
 
       - name: Checkout DataGateway API (default branch)
         uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -321,10 +321,6 @@ jobs:
       - name: Diff SQL dumps
         run: diff -s ~/generator_script_dump_1.sql ~/generator_script_dump_2.sql
 
-      - name: tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ failure() }}
-
       # Drop and re-create icatdb to remove generated data
       - name: Drop icatdb
         run: mysql -picatdbuserpw -uicatdbuser -e 'DROP DATABASE icatdb;'

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -294,7 +294,7 @@ jobs:
         run: poetry run python -m util.icat_db_generator
       - name: Drop modTime and createTime
         run: mysql -picatdbuserpw -uicatdbuser icatdb < /home/runner/work/datagateway-api/datagateway-api/util/columns_to_drop.sql
-      - name: Get SQL dump of dummy data to be prepared
+      - name: Get SQL dump of dummy data
         run: mysqldump -picatdbuserpw -uicatdbuser --skip-comments icatdb > ~/generator_script_dump_1.sql
 
       # Drop and re-create icatdb to remove generated data
@@ -305,6 +305,8 @@ jobs:
       # Regenerate table structure of icatdb
       - name: Reinstall ICAT Server
         run: cd /home/runner/install/icat.server; ./setup -vv install
+      - name: Add ICAT 5 triggers
+        run: cd /home/runner/install/icat.server; mysql -picatdbuserpw -uicatdbuser icatdb < create_triggers_mysql_5_0.sql
 
       - name: Add (new) dummy data to icatdb
         run: |
@@ -326,6 +328,8 @@ jobs:
       # Regenerate table structure of icatdb
       - name: Reinstall ICAT Server
         run: cd /home/runner/install/icat.server; ./setup -vv install
+      - name: Add ICAT 5 triggers
+        run: cd /home/runner/install/icat.server; mysql -picatdbuserpw -uicatdbuser icatdb < create_triggers_mysql_5_0.sql
 
       - name: Checkout DataGateway API (default branch)
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR will close #{issue number}

## Description
Fix consistency test by adding triggers for later stages of the test

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
Connect to #{issue number}
