### PR TITLE
Fix swagger docs at non-root paths #408

### DIFF
--- a/datagateway_api/config.yaml.example
+++ b/datagateway_api/config.yaml.example
@@ -30,3 +30,4 @@ host: "127.0.0.1"
 port: "5000"
 test_user_credentials: { username: "root", password: "pw" }
 test_mechanism: "simple"
+url_prefix: "/"

--- a/datagateway_api/src/api_start_utils.py
+++ b/datagateway_api/src/api_start_utils.py
@@ -69,8 +69,8 @@ class CustomErrorHandledApi(Api):
 
 def configure_datagateway_api_swaggerui_blueprint(flask_app):
     swaggerui_blueprint = get_swaggerui_blueprint(
-        base_url=Config.config.datagateway_api.extension,
-        api_url="/datagateway-api/openapi.json",
+        base_url=f"{Config.config.url_prefix}{Config.config.datagateway_api.extension}",
+        api_url=f"{Config.config.url_prefix}/datagateway-api/openapi.json",
         config={"app_name": "DataGateway API OpenAPI Spec"},
         blueprint_name="DataGateway API Swagger UI",
     )
@@ -83,8 +83,8 @@ def configure_datagateway_api_swaggerui_blueprint(flask_app):
 
 def configure_search_api_swaggerui_blueprint(flask_app):
     swaggerui_blueprint = get_swaggerui_blueprint(
-        base_url=Config.config.search_api.extension,
-        api_url="/search-api/openapi.json",
+        base_url=f"{Config.config.url_prefix}{Config.config.search_api.extension}",
+        api_url=f"{Config.config.url_prefix}/search-api/openapi.json",
         config={"app_name": "Search API OpenAPI Spec"},
         blueprint_name="Search API Swagger UI",
     )

--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -57,6 +57,9 @@ class DataGatewayAPI(BaseModel):
 
     _validate_extension = validator("extension", allow_reuse=True)(validate_extension)
 
+    def __getitem__(self, item):
+        return getattr(self, item)
+
     @validator("db_url", always=True)
     def require_db_config_value(cls, value, values):  # noqa: B902, N805
         """
@@ -147,6 +150,9 @@ class SearchAPI(BaseModel):
 
     _validate_extension = validator("extension", allow_reuse=True)(validate_extension)
 
+    def __getitem__(self, item):
+        return getattr(self, item)
+
 
 class TestUserCredentials(BaseModel):
     username: StrictStr
@@ -188,6 +194,9 @@ class APIConfig(BaseModel):
     url_prefix: StrictStr
 
     _validate_extension = validator("url_prefix", allow_reuse=True)(validate_extension)
+
+    def __getitem__(self, item):
+        return getattr(self, item)
 
     @classmethod
     def load(cls, path=Path(__file__).parent.parent.parent / "config.yaml"):

--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -32,6 +32,8 @@ def validate_extension(extension):
             raise ValueError("must start with '/'")
         if extension.endswith("/") and len(extension) != 1:
             raise ValueError("must not end with '/'")
+        if extension == "/":
+            extension = ""
 
     return extension
 
@@ -183,6 +185,9 @@ class APIConfig(BaseModel):
     search_api: Optional[SearchAPI]
     test_mechanism: Optional[StrictStr]
     test_user_credentials: Optional[TestUserCredentials]
+    url_prefix: StrictStr
+
+    _validate_extension = validator("url_prefix", allow_reuse=True)(validate_extension)
 
     @classmethod
     def load(cls, path=Path(__file__).parent.parent.parent / "config.yaml"):

--- a/datagateway_api/src/main.py
+++ b/datagateway_api/src/main.py
@@ -1,6 +1,8 @@
 import logging
 
 from flask import Flask
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from werkzeug.wrappers import Response
 
 from datagateway_api.src.api_start_utils import (
     create_api_endpoints,
@@ -9,8 +11,7 @@ from datagateway_api.src.api_start_utils import (
 )
 from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.logger_setup import setup_logger
-from werkzeug.middleware.dispatcher import DispatcherMiddleware
-from werkzeug.wrappers import Response
+
 
 setup_logger()
 log = logging.getLogger()
@@ -24,8 +25,7 @@ app.config["APPLICATION_ROOT"] = Config.config.url_prefix
 
 if __name__ == "__main__":
     app.wsgi_app = DispatcherMiddleware(
-        Response('Not Found', status=404),
-        {Config.config.url_prefix: app.wsgi_app}
+        Response("Not Found", status=404), {Config.config.url_prefix: app.wsgi_app},
     )
     app.run(
         host=Config.config.host,

--- a/datagateway_api/src/main.py
+++ b/datagateway_api/src/main.py
@@ -9,6 +9,8 @@ from datagateway_api.src.api_start_utils import (
 )
 from datagateway_api.src.common.config import Config
 from datagateway_api.src.common.logger_setup import setup_logger
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from werkzeug.wrappers import Response
 
 setup_logger()
 log = logging.getLogger()
@@ -18,8 +20,13 @@ app = Flask(__name__)
 api, specs = create_app_infrastructure(app)
 create_api_endpoints(app, api, specs)
 create_openapi_endpoints(app, specs)
+app.config["APPLICATION_ROOT"] = Config.config.url_prefix
 
 if __name__ == "__main__":
+    app.wsgi_app = DispatcherMiddleware(
+        Response('Not Found', status=404),
+        {Config.config.url_prefix: app.wsgi_app}
+    )
     app.run(
         host=Config.config.host,
         port=Config.config.port,

--- a/datagateway_api/src/swagger/apispec_flask_restful.py
+++ b/datagateway_api/src/swagger/apispec_flask_restful.py
@@ -9,6 +9,8 @@ from apispec import yaml_utils
 from apispec.exceptions import APISpecError
 import yaml
 
+from datagateway_api.src.common.config import Config
+
 
 def deduce_path(resource, **kwargs):
     """Find resource path using provided API or path itself"""
@@ -73,6 +75,7 @@ class RestfulPlugin(apispec.BasePlugin):
             resource = kwargs.pop("resource")
             path = deduce_path(resource, **kwargs)
             path = re.sub(r"<(?:[^:<>]+:)?([^<>]+)>", r"{\1}", path)
+            path = f"{Config.config.url_prefix}{path}"
             return path
         except Exception as exc:
             logging.getLogger(__name__).exception(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -59,6 +59,7 @@ def test_config_data():
         "port": "5000",
         "test_user_credentials": {"username": "root", "password": "pw"},
         "test_mechanism": "simple",
+        "url_prefix": "",
     }
 
 

--- a/test/integration/datagateway_api/db/endpoints/conftest.py
+++ b/test/integration/datagateway_api/db/endpoints/conftest.py
@@ -47,4 +47,5 @@ def test_config_data():
         "port": "5000",
         "test_user_credentials": {"username": "root", "password": "pw"},
         "test_mechanism": "simple",
+        "url_prefix": "",
     }

--- a/test/integration/datagateway_api/test_swagger_ui.py
+++ b/test/integration/datagateway_api/test_swagger_ui.py
@@ -1,0 +1,69 @@
+import json
+from unittest.mock import mock_open, patch
+
+from flask import Flask
+import pytest
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from werkzeug.wrappers import Response
+
+from datagateway_api.src.api_start_utils import (
+    create_api_endpoints,
+    create_app_infrastructure,
+    create_openapi_endpoints,
+)
+from datagateway_api.src.common.config import APIConfig
+
+
+@pytest.fixture(params=["", "/url-prefix"], ids=["No URL prefix", "Given a URL prefix"])
+def test_config_swagger(test_config_data, request):
+    test_config_data["url_prefix"] = request.param
+    test_config_data["datagateway_api"]["extension"] = (
+        "" if request.param == "" else "/datagateway-api"
+    )
+    test_config_data["search_api"]["extension"] = (
+        "/search-api" if request.param == "" else ""
+    )
+
+    with patch("builtins.open", mock_open(read_data=json.dumps(test_config_data))):
+        return APIConfig.load("test/path")
+
+
+class TestSwaggerUI:
+    @pytest.mark.parametrize(
+        "api_type",
+        [
+            pytest.param("datagateway_api", id="DataGateway API"),
+            pytest.param("search_api", id="Search API"),
+        ],
+    )
+    def test_swagger_ui(self, test_config_swagger, api_type, request):
+        # derived from the param IDs set above, used to assert the page title
+        api_name = request.node.callspec.id.split("-")[1]
+        with patch(
+            "datagateway_api.src.common.config.Config.config", test_config_swagger,
+        ):
+            test_app = Flask(__name__)
+            api, spec = create_app_infrastructure(test_app)
+            create_api_endpoints(test_app, api, spec)
+            create_openapi_endpoints(test_app, spec)
+            test_app.wsgi_app = DispatcherMiddleware(
+                Response("Not Found", status=404),
+                {test_config_swagger.url_prefix: test_app.wsgi_app},
+            )
+            test_client = test_app.test_client()
+
+            test_response = test_client.get(
+                f"{test_config_swagger.url_prefix}{test_config_swagger[api_type].extension}", # noqa: B950
+            )
+
+            test_response_string = test_response.get_data(as_text=True)
+
+            assert f"{api_name} OpenAPI Spec" in test_response_string
+            assert (
+                f"{test_config_swagger.url_prefix}{test_config_swagger[api_type].extension}/swagger-ui" # noqa: B950
+                in test_response_string
+            )
+            assert (
+                f"{test_config_swagger.url_prefix}/{api_type.replace('_', '-')}/openapi.json" # noqa: B950
+                in test_response_string
+            )

--- a/test/integration/datagateway_api/test_swagger_ui.py
+++ b/test/integration/datagateway_api/test_swagger_ui.py
@@ -53,17 +53,17 @@ class TestSwaggerUI:
             test_client = test_app.test_client()
 
             test_response = test_client.get(
-                f"{test_config_swagger.url_prefix}{test_config_swagger[api_type].extension}", # noqa: B950
+                f"{test_config_swagger.url_prefix}{test_config_swagger[api_type].extension}",  # noqa: B950
             )
 
             test_response_string = test_response.get_data(as_text=True)
 
             assert f"{api_name} OpenAPI Spec" in test_response_string
             assert (
-                f"{test_config_swagger.url_prefix}{test_config_swagger[api_type].extension}/swagger-ui" # noqa: B950
+                f"{test_config_swagger.url_prefix}{test_config_swagger[api_type].extension}/swagger-ui"  # noqa: B950
                 in test_response_string
             )
             assert (
-                f"{test_config_swagger.url_prefix}/{api_type.replace('_', '-')}/openapi.json" # noqa: B950
+                f"{test_config_swagger.url_prefix}/{api_type.replace('_', '-')}/openapi.json"  # noqa: B950
                 in test_response_string
             )

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -60,7 +60,7 @@ class TestAPIConfig:
     @pytest.mark.parametrize(
         "input_extension, expected_extension",
         [
-            pytest.param("/", "/", id="Slash"),
+            pytest.param("/", "", id="Slash"),
             pytest.param("", "", id="Empty string, implied slash"),
             pytest.param("/datagateway-api", "/datagateway-api", id="DataGateway API"),
             pytest.param(


### PR DESCRIPTION
This PR will close #408

## Description
Add a url_prefix config item which tells the app where it's expected to be mounted. I've added some code to take url_prefix into consideration in development, but otherwise we'd be expecting this to be done via a WSGI server e.g. Apache mod_wsgi

This then fixes the swagger UI as the UI files & openapi.json have the correct URLs. Every other URL in the app already worked fine with aliases as they're handled as part of WSGI spec

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] Run API locally with `url_prefix` option and set one of dg-api or search-api's aliases to "/" - test that the swagger UI is visible for both APIs
- [ ] Ideally also test with Apache mod_wsgi - or I can do a call with you and show you on my machine :)

## Agile Board Tracking
Closes #408
