### PR TITLE
Remove outdated paragraph on constraints on the setuptools version

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,11 +134,6 @@ jobs:
       - name: Create search_api_mapping.json
         run: cp datagateway_api/search_api_mapping.json.example datagateway_api/search_api_mapping.json
 
-      - name: Uninstall setuptools
-        run: poetry run pip uninstall -y setuptools
-      - name: Install older setuptools
-        run: poetry run pip install 'setuptools<58.0.0'
-
       - name: Install dependencies
         run: poetry install
 
@@ -281,12 +276,6 @@ jobs:
       - name: Install Poetry
         run: pip install poetry==1.1.9
 
-      # Installing an older version of setuptools for reasons explained at: https://github.com/icatproject/python-icat/issues/99
-      - name: Uninstall setuptools
-        run: poetry run pip uninstall -y setuptools
-      - name: Install older setuptools
-        run: poetry run pip install 'setuptools<58.0.0'
-
       - name: Install dependencies
         run: poetry install
 
@@ -341,12 +330,6 @@ jobs:
         run: cd /home/runner/work/datagateway-api/datagateway-api; cp datagateway_api/config.yaml.example datagateway_api/config.yaml
       - name: Create search_api_mapping.json
         run: cd /home/runner/work/datagateway-api/datagateway-api; cp datagateway_api/search_api_mapping.json.example datagateway_api/search_api_mapping.json
-
-      # Installing an older version of setuptools for reasons explained at: https://github.com/icatproject/python-icat/issues/99
-      - name: Uninstall setuptools
-        run: poetry run pip uninstall -y setuptools
-      - name: Install older setuptools
-        run: poetry run pip install 'setuptools<58.0.0'
 
       - name: Install dependencies
         run: poetry install

--- a/README.md
+++ b/README.md
@@ -129,26 +129,6 @@ Or you can specify the version you want to install from the listed versions with
 curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
 ```
 
-Before installing the API's dependencies, check the version of `setuptools`:
-
-```bash
-poetry run pip list | grep setuptools
-```
-
-If a version < 58.0.0 is not being used, changes need to be made so that a suitable
-version is being used. This is because Python ICAT uses `2to3` when building itself to
-ensure Python 3 import statements are used when using Python 3. 58.0.0 of setuptools
-[removes support of this tool during builds](https://setuptools.pypa.io/en/latest/history.html#v58-0-0).
-If a newer version of setuptools is used, you will likely face an error similar to
-what's described in
-[issue #99 of Python ICAT](https://github.com/icatproject/python-icat/issues/99). To use
-a supported version, execute the following commands:
-
-```bash
-poetry run pip uninstall -y setuptools
-poetry run pip install 'setuptools<58.0.0'
-```
-
 The dependencies for this repo are stored in `pyproject.toml`, with a more detailed
 version of this data in `poetry.lock`. The lock file is used to maintain the exact
 versions of dependencies from system to system. To install the dependencies, execute the

--- a/README.md
+++ b/README.md
@@ -371,22 +371,6 @@ Poetry environment:
 ModuleNotFoundError: No module named 'urlparse'
 ```
 
-Explanation of the cause for this issue can be found in a
-[Python ICAT issue](https://github.com/icatproject/python-icat/issues/99). Essentially,
-the version of `setuptools` used must be < 58.0.0
-([see above](#api-dependency-management-poetry) for further details). If you have
-already installed the API's dependencies (via `poetry install`), you will need to re-install `setuptools` (using a suitable version) and re-install Python ICAT so it can be rebuilt correctly. The following commands can be used for this process:
-
-```bash
-# Uninstall and re-install setuptools using a version < 58.0.0
-poetry run pip uninstall -y setuptools
-poetry run pip install 'setuptools<58.0.0'
-
-# Re-install Python ICAT so it can be built properly
-poetry remove python-icat
-poetry add python-icat=0.21.0
-```
-
 If using Python 3.10, please use Payara 5 on the ICAT stack which the API is being
 pointed at. There is a known issue when making HTTPS connections to Payara (via Python
 ICAT).

--- a/noxfile.py
+++ b/noxfile.py
@@ -110,19 +110,6 @@ def safety(session):
 @nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"], reuse_venv=True)
 def unit_tests(session):
     args = session.posargs
-    # Installing setuptools that will work with `2to3` which is used when building
-    # `python-icat` < 1.0. 58.0.0 removes support of this tool during builds:
-    # https://setuptools.pypa.io/en/latest/history.html#v58-0-0
-    # Ideally this would be done within `pyproject.toml` but specifying `setuptools` as
-    # a dependency requires Poetry 1.2:
-    # https://github.com/python-poetry/poetry/issues/4511#issuecomment-922420457
-    # Currently, only a pre-release exists for Poetry 1.2. Testing on the pre-release
-    # version didn't fix the `2to3` issue when building Python ICAT, perhaps because
-    # Python ICAT isn't built on the downgraded version for some reason?
-    session.run("pip", "uninstall", "-y", "setuptools")
-    # Not using `poetry run` as it errors on Windows OS when a version with the '<'
-    # sign is specified for a package
-    session.run("pip", "install", "setuptools<58.0.0")
     session.run("poetry", "install", external=True)
     session.run("pytest", "test/unit", *args)
 
@@ -130,18 +117,5 @@ def unit_tests(session):
 @nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"], reuse_venv=True)
 def integration_tests(session):
     args = session.posargs
-    # Installing setuptools that will work with `2to3` which is used when building
-    # `python-icat` < 1.0. 58.0.0 removes support of this tool during builds:
-    # https://setuptools.pypa.io/en/latest/history.html#v58-0-0
-    # Ideally this would be done within `pyproject.toml` but specifying `setuptools` as
-    # a dependency requires Poetry 1.2:
-    # https://github.com/python-poetry/poetry/issues/4511#issuecomment-922420457
-    # Currently, only a pre-release exists for Poetry 1.2. Testing on the pre-release
-    # version didn't fix the `2to3` issue when building Python ICAT, perhaps because
-    # Python ICAT isn't built on the downgraded version for some reason?
-    session.run("pip", "uninstall", "-y", "setuptools")
-    # Not using `poetry run` as it errors on Windows OS when a version with the '<'
-    # sign is specified for a package
-    session.run("pip", "install", "setuptools<58.0.0")
     session.run("poetry", "install", external=True)
     session.run("pytest", "test/integration", *args)


### PR DESCRIPTION
## Description
Suggest to remove an outdated paragraph from the README: according to `pyproject.toml` you are requiring `python-icat = "1.0.0"`. This version dropped support for Python 2 and does not use `2to3` any more. So there is no (known) constraint on the `setuptools` version in current `python-icat`.

## Testing Instructions
No code changes, only documentation update.
