### PR TITLE
Fix GitHub Actions Errors

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,6 +37,10 @@ jobs:
         run: pip install nox==2020.8.22
       - name: Install Poetry
         run: pip install poetry==1.1.9
+      # This fixes the issue with cachecontrol (https://github.com/psf/cachecontrol/issues/292).
+      # We will not be facing this issue when we upgrade to a newer Poetry version.
+      - name: Install Requests
+        run: pip install 'requests<2.30'
 
       # This command is a workaround for getting Poetry working with Python 3.10. An
       # fix is made in Poetry 1.2.0a2 but there is currently no official release for
@@ -275,6 +279,10 @@ jobs:
         run: cd /home/runner/work/datagateway-api/datagateway-api; cp datagateway_api/search_api_mapping.json.example datagateway_api/search_api_mapping.json
       - name: Install Poetry
         run: pip install poetry==1.1.9
+      # This fixes the issue with cachecontrol (https://github.com/psf/cachecontrol/issues/292).
+      # We will not be facing this issue when we upgrade to a newer Poetry version.
+      - name: Install Requests
+        run: pip install 'requests<2.30'
 
       - name: Install dependencies
         run: poetry install

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,7 +77,7 @@ def safety(session):
         # Ignore 51668 as the latest version of SQLAchemy and
         # Ignore 52322 and 52518 as the latest version of Gitpython does not
         # support python 3.6 which is still used in production
-        # Ignore 53325, 53326, and 54456 as the fixed versions do not support
+        # Ignore 53325, 53326, 54456, and 55261 as the fixed versions do not support
         # python 3.6
         session.run(
             "safety",
@@ -100,6 +100,8 @@ def safety(session):
             "53326",
             "--ignore",
             "54456",
+            "--ignore",
+            "55261",
         )
 
         try:

--- a/noxfile.py
+++ b/noxfile.py
@@ -75,9 +75,10 @@ def safety(session):
         # Ignore 50916 as the latest version of pydantic and
         # Ignore 51457 as the latest version of pytest and
         # Ignore 51668 as the latest version of SQLAchemy and
-        # Ignore 52355 and 52518 as the latest version of gitpython
-        # as they do not support
-        # python 3.6 which is still used in production
+        # Ignore 52322 and 52518 as the latest version of Gitpython does not
+        # support python 3.6 which is still used in production
+        # Ignore 53325, 53326, and 54456 as the fixed versions do not support
+        # python 3.6
         session.run(
             "safety",
             "check",
@@ -97,6 +98,8 @@ def safety(session):
             "53325",
             "--ignore",
             "53326",
+            "--ignore",
+            "54456",
         )
 
         try:


### PR DESCRIPTION
## Description
Fixes all the GitHub Action-related errors (https://github.com/ral-facilities/datagateway-api/actions/runs/5146527468). Also ignores the `werkzeug` vulnerability as the fix for this requires Python 3.7 or above.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?