### PR TITLE
Add more ignores on Safety session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -123,6 +123,12 @@ def safety(session):
             "62019",
             "--ignore",
             "62151",
+            "--ignore",
+            "62451",
+            "--ignore",
+            "62452",
+            "--ignore",
+            "62556",
         )
 
         try:


### PR DESCRIPTION
Hotfix for Safety job on CI - a PR has just been merged where the CI failed because of some new vulnerabilities that cannot be upgraded to the patched version because all patched versions have dropped support for Python 3.6.