### PR TITLE
Disable search API in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,14 @@ RUN --mount=type=cache,target=/root/.cache \
     ln -s "$DATAGATEWAY_API_LOCATION/datagateway_api/" datagateway_api; \
     \
     # Create config.yaml and search_api_mapping.json from their .example files \
-    cp datagateway_api/config.yaml.example datagateway_api/config.yaml; \
-    cp datagateway_api/search_api_mapping.json.example datagateway_api/search_api_mapping.json; \
+    #cp datagateway_api/config.yaml.example datagateway_api/config.yaml; \
+    #cp datagateway_api/search_api_mapping.json.example datagateway_api/search_api_mapping.json;
+
+# Copy config.yaml that has the search_api section removed
+COPY docker/config.yaml datagateway_api/config.yaml
+
+RUN --mount=type=cache,target=/root/.cache \
+    set -eux; \
     \
     # Create a non-root user to run as \
     addgroup -S datagateway-api; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN --mount=type=cache,target=/root/.cache \
     \
     # Create a symlink to the installed python module \
     DATAGATEWAY_API_LOCATION="$(python3 -m pip show datagateway_api | awk '/^Location:/ { print $2 }')"; \
-    ln -s "$DATAGATEWAY_API_LOCATION/datagateway_api/" datagateway_api; \
-    \
+    ln -s "$DATAGATEWAY_API_LOCATION/datagateway_api/" datagateway_api;
+    #\
     # Create config.yaml and search_api_mapping.json from their .example files \
     #cp datagateway_api/config.yaml.example datagateway_api/config.yaml; \
     #cp datagateway_api/search_api_mapping.json.example datagateway_api/search_api_mapping.json;

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -1,0 +1,20 @@
+---
+datagateway_api:
+  extension: "/"
+  backend: "python_icat"
+  client_cache_size: 5
+  client_pool_init_size: 2
+  client_pool_max_size: 5
+  db_url: "mysql+pymysql://icatdbuser:icatdbuserpw@localhost:3306/icatdb"
+  icat_url: "https://localhost:8181"
+  icat_check_cert: false
+flask_reloader: false
+log_level: "DEBUG"
+log_location: "/home/runner/work/datagateway/datagateway/datagateway-api/datagateway_api/logs.log"
+debug_mode: true
+generate_swagger: false
+host: "127.0.0.1"
+port: "5000"
+test_user_credentials: { username: "root", password: "pw" }
+test_mechanism: "simple"
+url_prefix: "/"


### PR DESCRIPTION
## Description
Remove the `search_api` section from `config.yaml` in the docker image, otherwise it fails to load since there is no search API backend available.

## Testing Instructions
- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] CI will build a container image for the PR and upload to Harbor. Test in kubernetes.

## Agile Board Tracking
N/A
