### PR TITLE
Update dependency ubuntu to v24 #515

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ on:
       - main
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -158,7 +158,7 @@ jobs:
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
 
   linting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Linting
     steps:
       - name: Setup Python
@@ -178,7 +178,7 @@ jobs:
         run: nox -s lint
 
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Code Formatting
     steps:
       - name: Setup Python
@@ -198,7 +198,7 @@ jobs:
         run: nox -s black
 
   safety:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Dependency Safety
     steps:
       - name: Setup Python
@@ -218,7 +218,7 @@ jobs:
         run: nox -s safety
 
   generator-script-testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     name: icatdb Generator Script Consistency Test
     steps:
@@ -372,7 +372,7 @@ jobs:
         run: diff -s ~/generator_script_dump_main.sql ~/generator_script_dump_1.sql
 
   pip-install-testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -424,7 +424,7 @@ jobs:
     # pushed to the main branch.
     needs: [tests, linting, formatting, safety, generator-script-testing, pip-install-testing]
     name: Docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out repo
       uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v3.5.3


### PR DESCRIPTION
This PR will close #515

## Description
Update dependency ubuntu to v24

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
Closes #515
