### PR TITLE
Remove support for older Python version (#517)

### DIFF
--- a/datagateway_api/src/datagateway_api/icat/filters.py
+++ b/datagateway_api/src/datagateway_api/icat/filters.py
@@ -51,6 +51,11 @@ class PythonICATWhereFilter(WhereFilter):
             where_filter = self.create_condition(self.field, "=", self.value)
         elif self.operation in ["ne", "neq"]:
             where_filter = self.create_condition(self.field, "!=", self.value)
+        elif self.operation == "isnull":
+            if self.value:
+                where_filter = self.create_condition(self.field, "IS NULL", None)
+            else:
+                where_filter = self.create_condition(self.field, "IS NOT NULL", None)
         elif self.operation == "like":
             where_filter = self.create_condition(self.field, "like", f"%{self.value}%")
         elif self.operation == "ilike":
@@ -131,6 +136,14 @@ class PythonICATWhereFilter(WhereFilter):
         """
 
         conditions = {}
+
+        # Handle unary operators (IS NULL, IS NOT NULL)
+        normalized_op = operator.strip().upper()
+        if normalized_op in ("IS NULL", "IS NOT NULL"):
+            conditions[attribute_name] = normalized_op
+            log.debug("Unary condition in ICAT where filter, %s", conditions)
+            return conditions
+
         # Removing quote marks when doing conditions with IN expressions or when a
         # distinct filter is used in a request
         jpql_value = (

--- a/datagateway_api/src/swagger/initialise_spec.py
+++ b/datagateway_api/src/swagger/initialise_spec.py
@@ -82,6 +82,11 @@ def initialise_datagateway_api_spec(spec):
                             },
                             {
                                 "type": "object",
+                                "title": "IS NULL",
+                                "properties": {"isnull": {"type": "boolean"}},
+                            },
+                            {
+                                "type": "object",
                                 "title": "Substring equality",
                                 "properties": {"like": {"type": "string"}},
                             },
@@ -156,6 +161,7 @@ def initialise_datagateway_api_spec(spec):
             "examples": {
                 "eq": {"value": [{"id": {"eq": 1}}]},
                 "ne": {"value": [{"id": {"ne": 1}}]},
+                "isnull": {"value": [{"publicationDate": {"isnull": True}}]},
                 "like": {"value": [{"name": {"like": "dog"}}]},
                 "lt": {"value": [{"id": {"lt": 10}}]},
                 "lte": {"value": [{"id": {"lte": 50}}]},

--- a/test/integration/datagateway_api/icat/filters/test_where_filter.py
+++ b/test/integration/datagateway_api/icat/filters/test_where_filter.py
@@ -11,6 +11,8 @@ class TestICATWhereFilter:
         [
             pytest.param("eq", 5, ["%s = '5'"], id="equal"),
             pytest.param("ne", 5, ["%s != '5'"], id="not equal (ne)"),
+            pytest.param("isnull", True, ["%s IS NULL"], id="isnull (true)"),
+            pytest.param("isnull", False, ["%s IS NOT NULL"], id="isnull (false)"),
             pytest.param("neq", 5, ["%s != '5'"], id="not equal (neq)"),
             pytest.param("like", 5, ["%s like '%%5%%'"], id="like"),
             pytest.param("ilike", 5, ["UPPER(%s) like UPPER('%%5%%')"], id="ilike"),


### PR DESCRIPTION
This PR will close #517

## Description
see #517

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
closes #517


## Notes 

- Upgraded poetry from 1.1.8 to 1.8.0. This is the maximum version that supports pydantic v2 
- Use fixture scope "function" for instead "package" 

      With scope="package", the same app instance is reused across multiple tests, which can cause state leakage (e.g., cached config, DB connections, etc.).
      scope="function" ensures a fresh app per test, which is safer in CI.
