### PR TITLE
feat: Add ability to supply settings file via volume #532

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve datagateway-api
 
 # Build stage
-FROM python:3.11-alpine3.17 AS builder
+FROM python:3.11-alpine@sha256:f07e2ace46f560f09a6eeec7b4913b80ee99546e749ef82342a419a326620856 AS builder
 
 WORKDIR /datagateway-api-build
 
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache \
 
 
 # Install & run stage
-FROM python:3.11-alpine3.17
+FROM python:3.11-alpine@sha256:f07e2ace46f560f09a6eeec7b4913b80ee99546e749ef82342a419a326620856
 
 WORKDIR /datagateway-api-run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve datagateway-api
 
 # Build stage
-FROM python:3.11-alpine3.17 as builder
+FROM python:3.11-alpine3.17 AS builder
 
 WORKDIR /datagateway-api-build
 
@@ -41,8 +41,8 @@ RUN --mount=type=cache,target=/root/.cache \
     addgroup -S datagateway-api; \
     adduser -S -D -G datagateway-api -H -h /datagateway-api-run datagateway-api; \
     \
-    # Change ownership of config.yaml - the entrypoint script will need to edit it \
-    chown datagateway-api:datagateway-api datagateway_api/config.yaml;
+    # Change ownership of settings location - the entrypoint script will need to edit it \
+    chown -R datagateway-api:datagateway-api datagateway_api/;
 
 USER datagateway-api
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,17 +1,21 @@
 #!/bin/sh -eu
 
-# Use a tempfile instead of sed -i so that only the file, not the directory needs to be writable
-TEMPFILE="$(mktemp)"
 
-# Set values in config.yaml from environment variables
-# No quotes for icat_check_cert because it's boolean
-sed -e "s|icat_url: \".*\"|icat_url: \"$ICAT_URL\"|" \
-    -e "s|icat_check_cert: .*|icat_check_cert: $ICAT_CHECK_CERT|" \
-    -e "s|log_location: \".*\"|log_location: \"$LOG_LOCATION\"|" \
-    datagateway_api/config.yaml > "$TEMPFILE"
+if [ ! -e /datagateway-api-run/datagateway_api/config.yaml ]; then
+    # file doesn't exist, so go with default settings file with env variable substitution
+    # if file exists, we skip this code as that means we've been supplied one from a mount
+    # Use a tempfile instead of sed -i so that only the file, not the directory needs to be writable
+    TEMPFILE="$(mktemp)"
 
-cat "$TEMPFILE" > datagateway_api/config.yaml
-rm "$TEMPFILE"
+    # Set values in config.yaml from environment variables
+    # No quotes for icat_check_cert because it's boolean
+    sed -e "s|icat_url: \".*\"|icat_url: \"$ICAT_URL\"|" \
+        -e "s|icat_check_cert: .*|icat_check_cert: $ICAT_CHECK_CERT|" \
+        -e "s|log_location: \".*\"|log_location: \"$LOG_LOCATION\"|" \
+        /datagateway-api-run/datagateway_api/config.yaml > "$TEMPFILE"
+
+    cat "$TEMPFILE" > /datagateway-api-run/datagateway_api/config.yaml
+    rm "$TEMPFILE"
 
 # Run the CMD instruction
 exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,6 +16,6 @@ if [ ! -e /datagateway-api-run/datagateway_api/config.yaml ]; then
 
     cat "$TEMPFILE" > /datagateway-api-run/datagateway_api/config.yaml
     rm "$TEMPFILE"
-
+fi
 # Run the CMD instruction
 exec "$@"


### PR DESCRIPTION
This PR will close #532

## Description
 Add ability to supply settings file via volume similar to data gateway and operations gateway 

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
closes #532
