### PR TITLE
Replace Reader logic with open data compatible cached functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,30 @@ cloned DataGateway API repository.
 This collection has not been updated for the search API endpoints, so can only be used
 to query DataGateway API.
 
+## Setup
+
+### v11.1.0
+
+Version 11.1.0 of the API will introduce changes to the reader functionality, and the reader account will require more permissions in order to determine if a user is associated with the entities they are querying. For ease of deployment, [setup_v11_1_0.py](/util/setup_v11_1_0.py) creates the necessary ICAT Rules for the reader account. It assumes that the reader User and corresponding Grouping already existing, and Rules for Datasets and Datafiles have been defined (as necessary for reader functionality in versions of the API <11.1). As it will create new Rule entities, to credentials used for the script should have permissions for this, such as an ICAT "root" account. As it loads from the main DataGateway API `Config` class and imports from Python-ICAT, it should be run in the same Python environment as DataGateway API. However, it does not require the API to be running as it communicates directly with ICAT server via the Python-ICAT bindings.
+
+```bash
+python util/setup_v11_1_0.py --help
+```
+```
+usage: datagateway_api_setup [-h] [--url URL] [-a AUTHENTICATOR] -u USERNAME [-p PASSWORD_FILE] [--allow-existing]
+
+options:
+  -h, --help            show this help message and exit
+  --url URL             The url address of the ICAT server.
+  -a AUTHENTICATOR, --authenticator AUTHENTICATOR
+                        The authentication mechanism to use for ICAT login.
+  -u USERNAME, --username USERNAME
+                        The username used for ICAT login.
+  -p PASSWORD_FILE, --password-file PASSWORD_FILE
+                        Location of file containing password for ICAT login. If not provided, the password will need to be provided by prompt.
+  --allow-existing      Iterates over each Entity and if it already exists, suppresses the ICATObjectAlreadyExists error.
+```
+
 # API Versioning
 
 This repository uses semantic versioning as the standard for version number

--- a/datagateway_api/config.yaml.example
+++ b/datagateway_api/config.yaml.example
@@ -6,6 +6,11 @@ datagateway_api:
   client_pool_max_size: 5
   icat_url: "https://localhost:8181"
   icat_check_cert: false
+  use_reader_for_performance:
+    enabled: false
+    reader_mechanism: simple
+    reader_username: reader
+    reader_password: readerpw
 search_api:
   extension: "/search-api"
   icat_url: "https://localhost:8181"
@@ -19,12 +24,6 @@ search_api:
     api_request_timeout: 5
     group: "documents" #corresponds to the defined group in the scoring app. https://github.com/panosc-eu/panosc-search-scoring/blob/master/docs/md/PaNOSC_Federated_Search_Results_Scoring_API.md#model
     limit: 1000
-# reader:
-#   mechanism: simple
-#   username: reader
-#   password: readerpw
-#   maxsize: 128
-#   ttl: 600
 reload: true
 host: "127.0.0.1"
 port: 5000

--- a/datagateway_api/config.yaml.example
+++ b/datagateway_api/config.yaml.example
@@ -6,11 +6,6 @@ datagateway_api:
   client_pool_max_size: 5
   icat_url: "https://localhost:8181"
   icat_check_cert: false
-  use_reader_for_performance:
-    enabled: false
-    reader_mechanism: simple
-    reader_username: reader
-    reader_password: readerpw
 search_api:
   extension: "/search-api"
   icat_url: "https://localhost:8181"
@@ -24,6 +19,12 @@ search_api:
     api_request_timeout: 5
     group: "documents" #corresponds to the defined group in the scoring app. https://github.com/panosc-eu/panosc-search-scoring/blob/master/docs/md/PaNOSC_Federated_Search_Results_Scoring_API.md#model
     limit: 1000
+# reader:
+#   mechanism: simple
+#   username: reader
+#   password: readerpw
+#   maxsize: 128
+#   ttl: 600
 reload: true
 host: "127.0.0.1"
 port: 5000

--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -46,10 +46,11 @@ def validate_extension(extension):
 DataGatewayAPIExtension = Annotated[StrictStr, AfterValidator(validate_extension)]
 
 
-class ReaderConfig(BaseModel):
-    mechanism: StrictStr
-    username: StrictStr
-    password: SecretStr
+class UseReaderForPerformance(BaseModel):
+    enabled: StrictBool
+    reader_mechanism: StrictStr
+    reader_username: StrictStr
+    reader_password: SecretStr
     maxsize: int = Field(
         default=128,
         description="Each cacheable function will store up to this many results in memory.",
@@ -57,13 +58,6 @@ class ReaderConfig(BaseModel):
     ttl: float = Field(
         default=600,
         description="Time-to-live for each of the cacheable functions in seconds.",
-    )
-    data_publication_type_public: str | None = Field(
-        default=None,
-        description=(
-            "If a Dataset belongs to a DataPublication of this type where publicationDate is set, it and its Datafiles "
-            "are considered open."
-        ),
     )
 
 
@@ -79,6 +73,7 @@ class DataGatewayAPI(BaseModel):
     extension: DataGatewayAPIExtension
     icat_check_cert: StrictBool
     icat_url: StrictStr
+    use_reader_for_performance: Optional[UseReaderForPerformance] = None
 
     def __getitem__(self, item):
         return getattr(self, item)
@@ -137,7 +132,6 @@ class APIConfig(BaseModel):
     """
 
     datagateway_api: Optional[DataGatewayAPI] = None
-    reader: ReaderConfig | None = None
     reload: Optional[StrictBool] = None
     host: Optional[StrictStr] = None
     port: Optional[StrictInt] = None

--- a/datagateway_api/src/common/config.py
+++ b/datagateway_api/src/common/config.py
@@ -1,13 +1,16 @@
+from functools import cached_property
 import logging
 from pathlib import Path
 import sys
-from typing import Annotated, Optional
+from typing import Annotated, Optional, Self
 
 from pydantic import (
     AfterValidator,
     BaseModel,
-    field_validator,
+    computed_field,
+    Field,
     model_validator,
+    SecretStr,
     StrictBool,
     StrictInt,
     StrictStr,
@@ -43,11 +46,25 @@ def validate_extension(extension):
 DataGatewayAPIExtension = Annotated[StrictStr, AfterValidator(validate_extension)]
 
 
-class UseReaderForPerformance(BaseModel):
-    enabled: StrictBool
-    reader_mechanism: StrictStr
-    reader_username: StrictStr
-    reader_password: StrictStr
+class ReaderConfig(BaseModel):
+    mechanism: StrictStr
+    username: StrictStr
+    password: SecretStr
+    maxsize: int = Field(
+        default=128,
+        description="Each cacheable function will store up to this many results in memory.",
+    )
+    ttl: float = Field(
+        default=600,
+        description="Time-to-live for each of the cacheable functions in seconds.",
+    )
+    data_publication_type_public: str | None = Field(
+        default=None,
+        description=(
+            "If a Dataset belongs to a DataPublication of this type where publicationDate is set, it and its Datafiles "
+            "are considered open."
+        ),
+    )
 
 
 class DataGatewayAPI(BaseModel):
@@ -62,7 +79,6 @@ class DataGatewayAPI(BaseModel):
     extension: DataGatewayAPIExtension
     icat_check_cert: StrictBool
     icat_url: StrictStr
-    use_reader_for_performance: Optional[UseReaderForPerformance] = None
 
     def __getitem__(self, item):
         return getattr(self, item)
@@ -121,6 +137,7 @@ class APIConfig(BaseModel):
     """
 
     datagateway_api: Optional[DataGatewayAPI] = None
+    reader: ReaderConfig | None = None
     reload: Optional[StrictBool] = None
     host: Optional[StrictStr] = None
     port: Optional[StrictInt] = None
@@ -131,6 +148,11 @@ class APIConfig(BaseModel):
 
     def __getitem__(self, item):
         return getattr(self, item)
+
+    @computed_field
+    @cached_property
+    def multi_api_count(self) -> int:
+        return (self.datagateway_api is not None) + (self.search_api is not None)
 
     @classmethod
     def load(cls, path=None):
@@ -159,49 +181,30 @@ class APIConfig(BaseModel):
         except (IOError, ValidationError) as error:
             sys.exit(f"An error occurred while trying to load the config data: {error}")
 
-    @field_validator("search_api")
-    @classmethod
-    def validate_api_extensions(cls, value, info):  # noqa: B902, N805
-        """
-        Checks that the DataGateway API and Search API extensions are not the same. An
-        error is raised, at which point the application exits, if the extensions are the
-        same.
+    @staticmethod
+    def _validate_api_extension(
+        extensions: set[DataGatewayAPIExtension],
+        sub_api_config: DataGatewayAPI | SearchAPI,
+    ) -> bool:
+        if sub_api_config is not None:
+            if sub_api_config.extension in extensions:
+                raise ValueError("All api extensions must be unique.")
 
-        :param cls: :class:`APIConfig` pointer
-        :param value: The value of the given config field
-        :param info: The config field values loaded before the given config field
-        """
-        if (
-            "datagateway_api" in info.data
-            and info.data["datagateway_api"] is not None
-            and value is not None
-            and info.data["datagateway_api"].extension == value.extension
-        ):
-            raise ValueError(
-                "extension cannot be the same as datagateway_api extension",
-            )
-
-        return value
+            extensions.add(sub_api_config.extension)
 
     @model_validator(mode="after")
-    def validate_root_path_usage(self):
+    def _validate_api_extensions(self) -> Self:
         """
-        Ensures that the root path ('/') is not used by both APIs at the same time.
-
-        Mounting an API at '/' is valid when running a single API instance, however
-        when both the DataGateway API and Search API are enabled, using '/' for either
-        would cause a routing conflict with the root FastAPI application. In this case,
-        both APIs must use distinct, non-root extensions.
+        Checks that the API extensions are not the same.
+        An error is raised, at which point the application exits, if the extensions are the same.
         """
-        dg_api = self.datagateway_api
-        search_api = self.search_api
-
-        if dg_api and search_api:
-            if dg_api.extension == "":
-                raise ValueError("datagateway_api extension cannot be '/' when search_api is also enabled")
-
-            if search_api.extension == "":
-                raise ValueError("search_api extension cannot be '/' when datagateway_api is also enabled")
+        extensions = set()
+        APIConfig._validate_api_extension(extensions=extensions, sub_api_config=self.datagateway_api)
+        APIConfig._validate_api_extension(extensions=extensions, sub_api_config=self.search_api)
+        if self.multi_api_count == 0:
+            raise ValueError("At least 1 API must be enabled.")
+        elif self.multi_api_count > 1 and "" in extensions:
+            raise ValueError("No API extension can be '/' when multiple APIs enabled.")
 
         return self
 

--- a/datagateway_api/src/datagateway_api/icat/helpers.py
+++ b/datagateway_api/src/datagateway_api/icat/helpers.py
@@ -427,7 +427,13 @@ def is_use_reader_for_performance_enabled() -> bool:
     Returns true is the 'use_reader_for_performance' section is present in the
     config file and 'enabled' in that section is set to true
     """
-    return Config.config.reader is not None
+    reader_config = Config.config.datagateway_api.use_reader_for_performance
+    if not reader_config:
+        return False
+    if not reader_config.enabled:
+        return False
+
+    return True
 
 
 def get_first_result_with_filters(client, entity_type, filters):

--- a/datagateway_api/src/datagateway_api/icat/helpers.py
+++ b/datagateway_api/src/datagateway_api/icat/helpers.py
@@ -362,44 +362,34 @@ def get_data_with_filters(client, entity_type, filters, aggregate=None):
     more details about the inner workings in ReaderQueryHandler
     """
 
-    if not is_use_reader_for_performance_enabled():
-        # just execute the query as normal
-        return execute_entity_query(client, entity_type, filters, aggregate=aggregate)
+    if is_use_reader_for_performance_enabled():
+        # See if this query is eligible to benefit from running faster using the reader account
+        reader_query = ReaderQueryHandler(entity_type, filters)
+        if reader_query.is_query_eligible_for_reader_performance():
+            log.info("Query is eligible to be passed as reader acount")
+            if reader_query.is_user_authorised_to_see_entity_id(client):
+                reader_client = ReaderQueryHandler.reader_client
+                log.info("Query to be executed as reader account")
+                try:
+                    return execute_entity_query(
+                        reader_client,
+                        entity_type,
+                        filters,
+                        aggregate=aggregate,
+                    )
+                except ICATSessionError:
+                    # re-login as reader and try the query again
+                    reader_client = reader_query.create_reader_client()
+                    return execute_entity_query(
+                        reader_client,
+                        entity_type,
+                        filters,
+                        aggregate=aggregate,
+                    )
 
-    # otherwise see if this query is eligible to benefit from running
-    # faster using the reader account
-    reader_query = ReaderQueryHandler(entity_type, filters)
-    if reader_query.is_query_eligible_for_reader_performance():
-        log.info("Query is eligible to be passed as reader acount")
-        if reader_query.is_user_authorised_to_see_entity_id(client):
-            reader_client = ReaderQueryHandler.reader_client
-            log.info("Query to be executed as reader account")
-            try:
-                results = execute_entity_query(
-                    reader_client,
-                    entity_type,
-                    filters,
-                    aggregate=aggregate,
-                )
-            except ICATSessionError:
-                # re-login as reader and try the query again
-                reader_client = reader_query.create_reader_client()
-                results = execute_entity_query(
-                    reader_client,
-                    entity_type,
-                    filters,
-                    aggregate=aggregate,
-                )
-            return results
-        else:
-            raise AuthenticationError(
-                "Not authorised to access the"
-                f" {ReaderQueryHandler.entity_filter_check[entity_type]}"
-                " you have filtered on",
-            )
-    else:
-        log.info("Query to be executed as user from request: %s", client.getUserName())
-        return execute_entity_query(client, entity_type, filters, aggregate=aggregate)
+    # We may still be able to get results, as we may be a root user who does not need direct association with the data
+    log.info("Query to be executed as user from request: %s", client.getUserName())
+    return execute_entity_query(client, entity_type, filters, aggregate=aggregate)
 
 
 def execute_entity_query(client, entity_type, filters, aggregate=None):

--- a/datagateway_api/src/datagateway_api/icat/helpers.py
+++ b/datagateway_api/src/datagateway_api/icat/helpers.py
@@ -427,13 +427,7 @@ def is_use_reader_for_performance_enabled() -> bool:
     Returns true is the 'use_reader_for_performance' section is present in the
     config file and 'enabled' in that section is set to true
     """
-    reader_config = Config.config.datagateway_api.use_reader_for_performance
-    if not reader_config:
-        return False
-    if not reader_config.enabled:
-        return False
-
-    return True
+    return Config.config.reader is not None
 
 
 def get_first_result_with_filters(client, entity_type, filters):

--- a/datagateway_api/src/datagateway_api/icat/reader_query_handler.py
+++ b/datagateway_api/src/datagateway_api/icat/reader_query_handler.py
@@ -45,8 +45,11 @@ class ReaderQueryHandler:
     # the first instance of this class is created and is refreshed when a login attempt
     # fails (due to an expired session ID)
     reader_client = None
-    maxsize = Config.config.reader and Config.config.reader.maxsize or 128  # cachetools default value
-    ttl = Config.config.reader and Config.config.reader.ttl or 600  # seconds, cachetools default value
+    maxsize = 128  # cachetools default value
+    ttl = 600  # seconds, cachetools default value
+    if Config.config.datagateway_api.use_reader_for_performance is not None:
+        maxsize = Config.config.datagateway_api.use_reader_for_performance.maxsize
+        ttl = Config.config.datagateway_api.use_reader_for_performance.ttl
 
     def __init__(self, entity_type: str, filters: List[QueryFilter]) -> None:
         self.entity_type = entity_type
@@ -70,10 +73,12 @@ class ReaderQueryHandler:
         cls.reader_client = ICATClient("datagateway_api")
         try:
             cls.reader_client.login(
-                auth=Config.config.reader.mechanism,
+                auth=Config.config.datagateway_api.use_reader_for_performance.reader_mechanism,
                 credentials={
-                    "username": Config.config.reader.username,
-                    "password": Config.config.reader.password.get_secret_value(),
+                    "username": Config.config.datagateway_api.use_reader_for_performance.reader_username,
+                    "password": (
+                        Config.config.datagateway_api.use_reader_for_performance.reader_password.get_secret_value()
+                    ),
                 },
             )
         except ICATSessionError as e:
@@ -110,7 +115,6 @@ class ReaderQueryHandler:
         Returns:
             int: ICAT id of the Dataset's parent Investigation.
         """
-        dataset_id = int(dataset_id)  # Ensure we actually have an int, and can't inject
         query = f"SELECT d.investigation.id FROM Dataset d WHERE d.id={dataset_id}"  # noqa: S608
         cls.refresh()
         investigation_ids = cls.reader_client.search(query)
@@ -122,39 +126,56 @@ class ReaderQueryHandler:
 
     @classmethod
     @ttl_cache(maxsize=maxsize, ttl=ttl)
-    def get_investigation_readers(cls, investigation_id: int) -> set[str]:
+    def get_investigation_users(cls, investigation_id: int) -> set[str]:
         """
         Args:
             investigation_id (int): ICAT Investigation.id.
 
         Returns:
             set[str]:
-                ICAT User.name of all InvestigationUsers and InstrumentScientists associated with the Investigation with
-                id `investigation_id`.
+                ICAT User.name of all InvestigationUsers associated with the Investigation with id `investigation_id`.
         """
-        investigation_id = int(investigation_id)  # Ensure we actually have an int, and can't inject
         query = (
-            "SELECT u.name FROM User u LEFT JOIN u.investigationUsers iu "  # noqa: S608
-            "LEFT JOIN u.instrumentScientists s LEFT JOIN s.instrument i LEFT JOIN i.investigationInstruments ii "
-            f"WHERE iu.investigation.id={investigation_id} OR ii.investigation.id={investigation_id}"
+            f"SELECT iu.user.name FROM InvestigationUser iu WHERE iu.investigation.id={investigation_id}"  # noqa: S608
         )
         cls.refresh()
         user_names = cls.reader_client.search(query=query)
-        log.debug("Found %s as readers for investigation.id=%s", user_names, investigation_id)
+        log.debug("Found %s as InvestigationUsers for investigation.id=%s", user_names, investigation_id)
         return set(user_names)
 
     @classmethod
-    def get_dataset_readers(cls, dataset_id: int) -> set[str]:
+    @ttl_cache(maxsize=maxsize, ttl=ttl)
+    def get_instrument_scientists(cls, investigation_id: int) -> set[str]:
         """
         Args:
-            dataset_id (int): ICAT Dataset.id.
+            investigation_id (int): ICAT Investigation.id.
 
         Returns:
             set[str]:
-                ICAT User.name of all InvestigationUsers and InstrumentScientists associated with the Dataset with id
-                `dataset_id`.
+                ICAT User.name of all InstrumentScientists associated with the Investigation with id `investigation_id`.
         """
-        return cls.get_investigation_readers(investigation_id=cls.get_investigation_id(dataset_id=dataset_id))
+        query = (
+            "SELECT s.user.name FROM InstrumentScientist s "  # noqa: S608
+            f"LEFT JOIN s.instrument.investigationInstruments ii WHERE ii.investigation.id={investigation_id}"
+        )
+        cls.refresh()
+        user_names = cls.reader_client.search(query=query)
+        log.debug("Found %s as InstrumentScientists for investigation.id=%s", user_names, investigation_id)
+        return set(user_names)
+
+    @classmethod
+    def is_user_allowed(cls, user_name: str, investigation_id: int) -> bool:
+        """
+        Args:
+            user_name (str): ICAT User.name.
+            investigation_id (int): ICAT Investigation.id.
+
+        Returns:
+            bool: If `user_name` has an association with `investigation_id` allowing read access.
+        """
+        return user_name in cls.get_investigation_users(
+            investigation_id=investigation_id,
+        ) or user_name in cls.get_instrument_scientists(investigation_id=investigation_id)
 
     @classmethod
     @ttl_cache(maxsize=maxsize, ttl=ttl)
@@ -166,19 +187,12 @@ class ReaderQueryHandler:
         Returns:
             bool: Whether the Dataset with `dataset_id` has been made open/public.
         """
-        if Config.config.reader is None or Config.config.reader.data_publication_type_public is None:
-            log.debug("Configuration for open data not defined.")
-            return False
-
-        dataset_id = int(dataset_id)  # Ensure we actually have an int, and can't inject
         query = (
             "SELECT dp.publicationDate FROM DataPublication dp JOIN dp.content c "  # noqa: S608
-            "JOIN c.dataCollectionDatasets dcd "
-            f"WHERE dp.type.name={Config.config.reader.data_publication_type_public!r} AND dcd.dataset.id={dataset_id}"
+            f"JOIN c.dataCollectionDatasets dcd WHERE dcd.dataset.id={dataset_id}"
         )
         cls.refresh()
         for publication_date in cls.reader_client.search(query):
-            log.debug(publication_date)
             if publication_date < datetime.now(tz=timezone.utc):
                 log.debug("dataset.id=%s is open", dataset_id)
                 return True
@@ -223,7 +237,7 @@ class ReaderQueryHandler:
                     "WHERE filter relevant for reader query checking: %s",
                     query_filter,
                 )
-                self.where_filter_entity_id = query_filter.value
+                self.where_filter_entity_id = int(query_filter.value)
                 return query_filter
 
         return None
@@ -240,16 +254,17 @@ class ReaderQueryHandler:
         log.info("Checking to see if user '%s' can see %s=%s", user_name, id_field, self.where_filter_entity_id)
 
         if self.entity_type == "Dataset":
-            if user_name in self.get_investigation_readers(investigation_id=self.where_filter_entity_id):
+            if ReaderQueryHandler.is_user_allowed(user_name=user_name, investigation_id=self.where_filter_entity_id):
                 log.debug("User is authorised to see investigation.id=%s", self.where_filter_entity_id)
                 return True
 
         elif self.entity_type == "Datafile":
-            if user_name in self.get_dataset_readers(dataset_id=self.where_filter_entity_id):
+            investigation_id = ReaderQueryHandler.get_investigation_id(dataset_id=self.where_filter_entity_id)
+            if ReaderQueryHandler.is_user_allowed(
+                user_name=user_name,
+                investigation_id=investigation_id,
+            ) or ReaderQueryHandler.is_dataset_open(dataset_id=self.where_filter_entity_id):
                 log.debug("User is authorised to see dataset.id=%s", self.where_filter_entity_id)
-                return True
-            elif self.is_dataset_open(dataset_id=self.where_filter_entity_id):
-                log.debug("dataset.id=%s is open", self.where_filter_entity_id)
                 return True
 
         log.debug("User not authorised to see %s=%s", id_field, self.where_filter_entity_id)

--- a/datagateway_api/src/datagateway_api/icat/reader_query_handler.py
+++ b/datagateway_api/src/datagateway_api/icat/reader_query_handler.py
@@ -1,15 +1,15 @@
+from datetime import datetime, timezone
 import logging
 from typing import List, Optional
 
+from cachetools.func import ttl_cache
 from icat.exception import ICATSessionError
 
 from datagateway_api.src.common.config import Config
-from datagateway_api.src.common.exceptions import PythonICATError
-from datagateway_api.src.common.filter_order_handler import FilterOrderHandler
+from datagateway_api.src.common.exceptions import MissingRecordError, PythonICATError
 from datagateway_api.src.common.filters import QueryFilter
 from datagateway_api.src.datagateway_api.icat.filters import PythonICATWhereFilter
 from datagateway_api.src.datagateway_api.icat.icat_client_pool import ICATClient
-from datagateway_api.src.datagateway_api.icat.query import ICATQuery
 
 log = logging.getLogger()
 
@@ -45,6 +45,8 @@ class ReaderQueryHandler:
     # the first instance of this class is created and is refreshed when a login attempt
     # fails (due to an expired session ID)
     reader_client = None
+    maxsize = Config.config.reader and Config.config.reader.maxsize or 128  # cachetools default value
+    ttl = Config.config.reader and Config.config.reader.ttl or 600  # seconds, cachetools default value
 
     def __init__(self, entity_type: str, filters: List[QueryFilter]) -> None:
         self.entity_type = entity_type
@@ -57,31 +59,132 @@ class ReaderQueryHandler:
         if not ReaderQueryHandler.reader_client:
             self.create_reader_client()
 
-    def create_reader_client(self) -> ICATClient:
+    @classmethod
+    def create_reader_client(cls) -> ICATClient:
         """
         Create a new client (assigning it as a class variable) and login using the
         reader's credentials. If the credentials aren't valid, a PythonICATError is
         raised (resulting in a 500). The client object is returned
         """
-
         log.info("Creating reader_client")
-        ReaderQueryHandler.reader_client = ICATClient("datagateway_api")
-        reader_config = Config.config.datagateway_api.use_reader_for_performance
-        login_credentals = {
-            "username": reader_config.reader_username,
-            "password": reader_config.reader_password,
-        }
+        cls.reader_client = ICATClient("datagateway_api")
         try:
-            ReaderQueryHandler.reader_client.login(
-                reader_config.reader_mechanism,
-                login_credentals,
+            cls.reader_client.login(
+                auth=Config.config.reader.mechanism,
+                credentials={
+                    "username": Config.config.reader.username,
+                    "password": Config.config.reader.password.get_secret_value(),
+                },
             )
         except ICATSessionError as e:
             log.error("User credentials for reader account aren't valid")
-            raise PythonICATError(
-                "Internal error with reader account configuration",
-            ) from e
-        return ReaderQueryHandler.reader_client
+            raise PythonICATError("Internal error with reader account configuration") from e
+
+        return cls.reader_client
+
+    @classmethod
+    def refresh(cls) -> None:
+        """
+        Refresh `cls.reader_client` if it is defined and is close to expiring.
+        If it is not defined, or has already expired, create a new one.
+        """
+        if cls.reader_client is not None and cls.reader_client.sessionId is not None:
+            try:
+                cls.reader_client.autoRefresh()
+                return
+            except ICATSessionError:
+                log.debug("Reader session expired")
+
+        cls.create_reader_client()
+
+    @classmethod
+    @ttl_cache(maxsize=maxsize, ttl=ttl)
+    def get_investigation_id(cls, dataset_id: int) -> int:
+        """
+        Args:
+            dataset_id (int): ICAT Dataset.id.
+
+        Raises:
+            MissingRecordError: If no Dataset with `dataset_id` is found.
+
+        Returns:
+            int: ICAT id of the Dataset's parent Investigation.
+        """
+        dataset_id = int(dataset_id)  # Ensure we actually have an int, and can't inject
+        query = f"SELECT d.investigation.id FROM Dataset d WHERE d.id={dataset_id}"  # noqa: S608
+        cls.refresh()
+        investigation_ids = cls.reader_client.search(query)
+        if len(investigation_ids) == 0:
+            raise MissingRecordError(f"No Dataset found for id={dataset_id}")
+
+        log.debug("Found investigation.id=%s for dataset.id=%s", investigation_ids[0], dataset_id)
+        return investigation_ids[0]
+
+    @classmethod
+    @ttl_cache(maxsize=maxsize, ttl=ttl)
+    def get_investigation_readers(cls, investigation_id: int) -> set[str]:
+        """
+        Args:
+            investigation_id (int): ICAT Investigation.id.
+
+        Returns:
+            set[str]:
+                ICAT User.name of all InvestigationUsers and InstrumentScientists associated with the Investigation with
+                id `investigation_id`.
+        """
+        investigation_id = int(investigation_id)  # Ensure we actually have an int, and can't inject
+        query = (
+            "SELECT u.name FROM User u LEFT JOIN u.investigationUsers iu "  # noqa: S608
+            "LEFT JOIN u.instrumentScientists s LEFT JOIN s.instrument i LEFT JOIN i.investigationInstruments ii "
+            f"WHERE iu.investigation.id={investigation_id} OR ii.investigation.id={investigation_id}"
+        )
+        cls.refresh()
+        user_names = cls.reader_client.search(query=query)
+        log.debug("Found %s as readers for investigation.id=%s", user_names, investigation_id)
+        return set(user_names)
+
+    @classmethod
+    def get_dataset_readers(cls, dataset_id: int) -> set[str]:
+        """
+        Args:
+            dataset_id (int): ICAT Dataset.id.
+
+        Returns:
+            set[str]:
+                ICAT User.name of all InvestigationUsers and InstrumentScientists associated with the Dataset with id
+                `dataset_id`.
+        """
+        return cls.get_investigation_readers(investigation_id=cls.get_investigation_id(dataset_id=dataset_id))
+
+    @classmethod
+    @ttl_cache(maxsize=maxsize, ttl=ttl)
+    def is_dataset_open(cls, dataset_id: int) -> bool:
+        """
+        Args:
+            dataset_id (int): ICAT Dataset.id.
+
+        Returns:
+            bool: Whether the Dataset with `dataset_id` has been made open/public.
+        """
+        if Config.config.reader is None or Config.config.reader.data_publication_type_public is None:
+            log.debug("Configuration for open data not defined.")
+            return False
+
+        dataset_id = int(dataset_id)  # Ensure we actually have an int, and can't inject
+        query = (
+            "SELECT dp.publicationDate FROM DataPublication dp JOIN dp.content c "  # noqa: S608
+            "JOIN c.dataCollectionDatasets dcd "
+            f"WHERE dp.type.name={Config.config.reader.data_publication_type_public!r} AND dcd.dataset.id={dataset_id}"
+        )
+        cls.refresh()
+        for publication_date in cls.reader_client.search(query):
+            log.debug(publication_date)
+            if publication_date < datetime.now(tz=timezone.utc):
+                log.debug("dataset.id=%s is open", dataset_id)
+                return True
+
+        log.debug("dataset.id=%s is closed", dataset_id)
+        return False
 
     def check_eligibility(self) -> bool:
         """
@@ -132,35 +235,22 @@ class ReaderQueryHandler:
         created and sent to ICAT for execution - the query is performed using the
         session ID provided in the request
         """
+        user_name = client.getUserName()
+        id_field = ReaderQueryHandler.entity_filter_check[self.entity_type]
+        log.info("Checking to see if user '%s' can see %s=%s", user_name, id_field, self.where_filter_entity_id)
 
-        log.info(
-            "Checking to see if user '%s' can see '%s' = %s",
-            client.getUserName(),
-            ReaderQueryHandler.entity_filter_check[self.entity_type],
-            self.where_filter_entity_id,
-        )
-        access_query = ICATQuery(
-            client,
-            ReaderQueryHandler.parent_entity_lookup[self.entity_type],
-        )
-        id_check = PythonICATWhereFilter("id", self.where_filter_entity_id, "eq")
-        access_filter_handler = FilterOrderHandler()
-        access_filter_handler.manage_icat_filters([id_check], access_query.query)
-        results = access_query.execute_query(client)
+        if self.entity_type == "Dataset":
+            if user_name in self.get_investigation_readers(investigation_id=self.where_filter_entity_id):
+                log.debug("User is authorised to see investigation.id=%s", self.where_filter_entity_id)
+                return True
 
-        if results:
-            log.debug(
-                "User is authorised to see '%s%s'",
-                ReaderQueryHandler.entity_filter_check[self.entity_type],
-                self.where_filter_entity_id,
-            )
-            user_authorised = True
-        else:
-            log.debug(
-                "User is NOT authorised to see '%s%s'",
-                ReaderQueryHandler.entity_filter_check[self.entity_type],
-                self.where_filter_entity_id,
-            )
-            user_authorised = False
+        elif self.entity_type == "Datafile":
+            if user_name in self.get_dataset_readers(dataset_id=self.where_filter_entity_id):
+                log.debug("User is authorised to see dataset.id=%s", self.where_filter_entity_id)
+                return True
+            elif self.is_dataset_open(dataset_id=self.where_filter_entity_id):
+                log.debug("dataset.id=%s is open", self.where_filter_entity_id)
+                return True
 
-        return user_authorised
+        log.debug("User not authorised to see %s=%s", id_field, self.where_filter_entity_id)
+        return False

--- a/datagateway_api/src/main.py
+++ b/datagateway_api/src/main.py
@@ -129,21 +129,16 @@ def create_search_api_app() -> FastAPI | None:
     return None
 
 
-if datagateway_api_enabled and search_api_enabled:
+if Config.config.multi_api_count > 1:
     app = FastAPI(
         title="DataGateway",
         root_path=Config.config.url_prefix,
         separate_input_output_schemas=False,
     )
-
-    app.mount(
-        Config.config.datagateway_api.extension,
-        create_datagateway_app(),
-    )
-    app.mount(
-        Config.config.search_api.extension,
-        create_search_api_app(),
-    )
+    if datagateway_api_enabled:
+        app.mount(path=Config.config.datagateway_api.extension, app=create_datagateway_app())
+    if search_api_enabled:
+        app.mount(path=Config.config.search_api.extension, app=create_search_api_app())
 
 elif datagateway_api_enabled:
     app = create_datagateway_app()

--- a/test/integration/datagateway_api/icat/test_reader_performance.py
+++ b/test/integration/datagateway_api/icat/test_reader_performance.py
@@ -108,6 +108,13 @@ def icat_user_client() -> Client:
     return client
 
 
+@pytest.fixture(scope="class")
+def icat_root_client() -> Client:
+    client = Client(url=Config.config.datagateway_api.icat_url, checkCert=Config.config.datagateway_api.icat_check_cert)
+    client.login(auth="simple", credentials={"username": "root", "password": "pw"})
+    return client
+
+
 @pytest.fixture(scope="function")
 def enable_reader_config() -> Generator[None, None, None]:
     Config.config.datagateway_api.use_reader_for_performance.enabled = True
@@ -187,56 +194,16 @@ class TestReaderPerformance:
         )
 
     @pytest.mark.parametrize(
-        ["entity_type", "filters", "results_length", "exception"],
+        ["entity_type", "filters", "results_length"],
         [
-            pytest.param(
-                "Dataset",
-                [PythonICATWhereFilter("investigation.id", 1, "eq")],
-                None,
-                "Not authorised to access the investigation.id you have filtered on",
-            ),
-            pytest.param(
-                "Datafile",
-                [PythonICATWhereFilter("dataset.id", 1, "eq")],
-                None,
-                "Not authorised to access the dataset.id you have filtered on",
-            ),
-            pytest.param(
-                "Dataset",
-                [PythonICATWhereFilter("investigation.id", 2, "eq")],
-                2,
-                None,
-            ),
-            pytest.param(
-                "Datafile",
-                [PythonICATWhereFilter("dataset.id", 2, "eq")],
-                16,
-                None,
-            ),
-            pytest.param(
-                "Dataset",
-                [PythonICATWhereFilter("investigation.id", 3, "eq")],
-                2,
-                None,
-            ),
-            pytest.param(
-                "Datafile",
-                [PythonICATWhereFilter("dataset.id", 3, "eq")],
-                16,
-                None,
-            ),
-            pytest.param(
-                "Dataset",
-                [PythonICATWhereFilter("investigation.id", 4, "eq")],
-                2,
-                None,
-            ),
-            pytest.param(
-                "Datafile",
-                [PythonICATWhereFilter("dataset.id", 4, "eq")],
-                16,
-                None,
-            ),
+            pytest.param("Dataset", [PythonICATWhereFilter("investigation.id", 1, "eq")], 0),
+            pytest.param("Datafile", [PythonICATWhereFilter("dataset.id", 1, "eq")], 0),
+            pytest.param("Dataset", [PythonICATWhereFilter("investigation.id", 2, "eq")], 2),
+            pytest.param("Datafile", [PythonICATWhereFilter("dataset.id", 2, "eq")], 16),
+            pytest.param("Dataset", [PythonICATWhereFilter("investigation.id", 3, "eq")], 2),
+            pytest.param("Datafile", [PythonICATWhereFilter("dataset.id", 3, "eq")], 16),
+            pytest.param("Dataset", [PythonICATWhereFilter("investigation.id", 4, "eq")], 2),
+            pytest.param("Datafile", [PythonICATWhereFilter("dataset.id", 4, "eq")], 16),
         ],
     )
     def test_execute_query_as_reader(
@@ -248,24 +215,15 @@ class TestReaderPerformance:
         entity_type: str,
         filters: list[PythonICATWhereFilter],
         results_length: int,
-        exception: str,
     ) -> None:
-        if exception:
-            with pytest.raises(AuthenticationError, match=exception):
-                get_data_with_filters(client=icat_user_client, entity_type=entity_type, filters=filters)
-        else:
-            results = get_data_with_filters(client=icat_user_client, entity_type=entity_type, filters=filters)
-            assert len(results) == results_length
+        results = get_data_with_filters(client=icat_user_client, entity_type=entity_type, filters=filters)
+        assert len(results) == results_length
 
     @pytest.mark.parametrize(
-        ["filters", "results_length", "exception"],
+        ["filters", "results_length"],
         [
-            pytest.param(
-                [PythonICATWhereFilter("dataset.id", 7, "eq")],
-                None,
-                "Not authorised to access the dataset.id you have filtered on",
-            ),
-            pytest.param([PythonICATWhereFilter("dataset.id", 6, "eq")], 16, None),
+            pytest.param([PythonICATWhereFilter("dataset.id", 6, "eq")], 16, id="Dataset in a DataPublication"),
+            pytest.param([PythonICATWhereFilter("dataset.id", 7, "eq")], 0, id="Dataset not in a DataPublication"),
         ],
     )
     def test_open_data(
@@ -276,14 +234,29 @@ class TestReaderPerformance:
         icat_user_client: Client,
         filters: list[PythonICATWhereFilter],
         results_length: int,
-        exception: str,
     ) -> None:
-        if exception:
-            with pytest.raises(AuthenticationError, match=exception):
-                get_data_with_filters(client=icat_user_client, entity_type="Datafile", filters=filters)
-        else:
-            results = get_data_with_filters(client=icat_user_client, entity_type="Datafile", filters=filters)
-            assert len(results) == results_length
+        results = get_data_with_filters(client=icat_user_client, entity_type="Datafile", filters=filters)
+        assert len(results) == results_length
+
+    @pytest.mark.parametrize(
+        ["entity_type", "filters", "results_length"],
+        [
+            pytest.param("Dataset", [PythonICATWhereFilter("investigation.id", 1, "eq")], 2),
+            pytest.param("Datafile", [PythonICATWhereFilter("dataset.id", 1, "eq")], 15),
+        ],
+    )
+    def test_root_access(
+        self,
+        enable_reader_config: None,
+        enable_reader_permissions: None,
+        associate_data_publication: None,
+        icat_root_client: Client,
+        entity_type: str,
+        filters: list[PythonICATWhereFilter],
+        results_length: int,
+    ) -> None:
+        results = get_data_with_filters(client=icat_root_client, entity_type=entity_type, filters=filters)
+        assert len(results) == results_length
 
     def test_refresh(self, enable_reader_config: None) -> None:
         client = Client(

--- a/test/integration/datagateway_api/icat/test_reader_performance.py
+++ b/test/integration/datagateway_api/icat/test_reader_performance.py
@@ -1,8 +1,12 @@
-from unittest.mock import patch
+from datetime import datetime
+import time
+from typing import Generator
 
+from icat.client import Client
 import pytest
 
-from datagateway_api.src.common.config import Config
+from datagateway_api.src.common.config import APIConfig, Config, ReaderConfig
+from datagateway_api.src.common.exceptions import AuthenticationError, MissingRecordError, PythonICATError
 from datagateway_api.src.datagateway_api.icat.filters import (
     PythonICATLimitFilter,
     PythonICATOrderFilter,
@@ -16,6 +20,118 @@ from datagateway_api.src.datagateway_api.icat.icat_client_pool import ICATClient
 from datagateway_api.src.datagateway_api.icat.reader_query_handler import (
     ReaderQueryHandler,
 )
+
+
+@pytest.fixture(scope="class")
+def enable_reader_permissions(icat_client: Client) -> Generator[None, None, None]:
+    entities = []
+    try:
+        user = icat_client.new(obj="User", name="simple/reader")
+        grouping = icat_client.new(obj="Grouping", name="reader")
+        user.id, grouping.id = icat_client.createMany(beans=[user, grouping])
+        entities = [user, grouping]
+        icat_client.createMany(
+            beans=[
+                icat_client.new("UserGroup", user=user, grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="User", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="InvestigationUser", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="InstrumentScientist", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="Instrument", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="InvestigationInstrument", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="Investigation", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="Dataset", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="Datafile", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="DataPublication", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="DataCollection", grouping=grouping),
+                icat_client.new(obj="Rule", crudFlags="R", what="DataCollectionDataset", grouping=grouping),
+            ],
+        )
+        yield
+    finally:
+        icat_client.deleteMany(beans=entities)
+
+
+@pytest.fixture(scope="class")
+def associate_icat_user(icat_client: Client) -> Generator[None, None, None]:
+    user = None
+    try:
+        user = icat_client.new(
+            obj="User",
+            name="simple/icatuser",
+            investigationUsers=[
+                icat_client.new(obj="InvestigationUser", role="", investigation=icat_client.get("Investigation", 2)),
+                icat_client.new(obj="InvestigationUser", role="", investigation=icat_client.get("Investigation", 3)),
+            ],
+            instrumentScientists=[
+                icat_client.new(obj="InstrumentScientist", instrument=icat_client.get("Instrument", 13)),
+                icat_client.new(obj="InstrumentScientist", instrument=icat_client.get("Instrument", 14)),
+            ],
+        )
+        user.create()
+        yield
+    finally:
+        if user is not None and user.id is not None:
+            icat_client.delete(bean=user)
+
+
+@pytest.fixture(scope="class")
+def associate_data_publication(icat_client: Client) -> Generator[None, None, None]:
+    data_collection = None
+    try:
+        data_collection = icat_client.new(
+            obj="DataCollection",
+            dataPublications=[
+                icat_client.new(
+                    obj="DataPublication",
+                    title="title",
+                    pid="pid",
+                    publicationDate=datetime.now(),
+                    facility=icat_client.get("Facility", 1),
+                    type=icat_client.get("DataPublicationType", 1),
+                ),
+            ],
+            dataCollectionDatasets=[
+                icat_client.new(obj="DataCollectionDataset", dataset=icat_client.get("Dataset", 6)),
+            ],
+        )
+        data_collection.create()
+        yield
+    finally:
+        if data_collection is not None and data_collection.id is not None:
+            icat_client.delete(bean=data_collection)
+
+
+@pytest.fixture(scope="class")
+def icat_user_client() -> Client:
+    client = Client(url=Config.config.datagateway_api.icat_url, checkCert=Config.config.datagateway_api.icat_check_cert)
+    client.login(auth="simple", credentials={"username": "icatuser", "password": "icatuserpw"})
+    return client
+
+
+@pytest.fixture(scope="function")
+def enable_reader_config() -> Generator[None, None, None]:
+    Config.config.reader = ReaderConfig(mechanism="simple", username="reader", password="readerpw")  # noqa: S106
+    yield
+    Config.config = APIConfig.load()
+
+
+@pytest.fixture(scope="function")
+def enable_reader_open_config() -> Generator[None, None, None]:
+    Config.config.reader = ReaderConfig(  # noqa: S106
+        mechanism="simple",
+        username="reader",
+        password="readerpw",
+        data_publication_type_public="center",
+    )
+    yield
+    Config.config = APIConfig.load()
+
+
+@pytest.fixture(scope="function")
+def enable_reader_bad_config() -> Generator[None, None, None]:
+    Config.config.reader = ReaderConfig(mechanism="bad", username="reader", password="readerpw")  # noqa: S106
+    yield
+    Config.config = APIConfig.load()
 
 
 class TestReaderPerformance:
@@ -58,13 +174,9 @@ class TestReaderPerformance:
             ),
         ],
     )
-    @patch(
-        "datagateway_api.src.common.config.Config.config.datagateway_api.use_reader_for_performance.enabled",
-        return_value=True,
-    )
     def test_eligbility(
         self,
-        _,
+        enable_reader_config: None,
         test_entity_type,
         test_query_filters,
         expected_eligbility,
@@ -77,54 +189,132 @@ class TestReaderPerformance:
         query_eligbility = test_handler.is_query_eligible_for_reader_performance()
         assert query_eligbility == expected_eligbility
 
-    def test_reader_client(self):
+    def test_reader_client(self, enable_reader_config: None):
         ReaderQueryHandler("Datafile", [])
         reader_client = ReaderQueryHandler.reader_client
         assert isinstance(reader_client, ICATClient)
-
-        reader_config = Config.config.datagateway_api.use_reader_for_performance
-        assert reader_client.getUserName() == f"{reader_config.reader_mechanism}/{reader_config.reader_username}"
+        assert reader_client.getUserName() == f"{Config.config.reader.mechanism}/{Config.config.reader.username}"
 
     @pytest.mark.parametrize(
-        "test_entity_type, test_query_filters, expected_authorisation",
+        ["entity_type", "filters", "results_length", "exception"],
         [
+            pytest.param(
+                "Dataset",
+                [PythonICATWhereFilter("investigation.id", 1, "eq")],
+                None,
+                "Not authorised to access the investigation.id you have filtered on",
+            ),
+            pytest.param(
+                "Datafile",
+                [PythonICATWhereFilter("dataset.id", 1, "eq")],
+                None,
+                "Not authorised to access the dataset.id you have filtered on",
+            ),
+            pytest.param(
+                "Dataset",
+                [PythonICATWhereFilter("investigation.id", 2, "eq")],
+                2,
+                None,
+            ),
+            pytest.param(
+                "Datafile",
+                [PythonICATWhereFilter("dataset.id", 2, "eq")],
+                16,
+                None,
+            ),
+            pytest.param(
+                "Dataset",
+                [PythonICATWhereFilter("investigation.id", 3, "eq")],
+                2,
+                None,
+            ),
             pytest.param(
                 "Datafile",
                 [PythonICATWhereFilter("dataset.id", 3, "eq")],
-                True,
-                id="Typical positive use case",
+                16,
+                None,
+            ),
+            pytest.param(
+                "Dataset",
+                [PythonICATWhereFilter("investigation.id", 4, "eq")],
+                2,
+                None,
             ),
             pytest.param(
                 "Datafile",
-                [PythonICATWhereFilter("dataset.id", 99999, "eq")],
-                False,
-                id="Typical negative use case",
+                [PythonICATWhereFilter("dataset.id", 4, "eq")],
+                16,
+                None,
             ),
         ],
     )
-    def test_is_user_authorised(
+    def test_execute_query_as_reader(
         self,
-        icat_client,
-        test_entity_type,
-        test_query_filters,
-        expected_authorisation,
-    ):
-        test_handler = ReaderQueryHandler(test_entity_type, test_query_filters)
-        is_authorised = test_handler.is_user_authorised_to_see_entity_id(icat_client)
-        assert is_authorised == expected_authorisation
+        enable_reader_config: None,
+        enable_reader_permissions: None,
+        associate_icat_user: None,
+        icat_user_client: Client,
+        entity_type: str,
+        filters: list[PythonICATWhereFilter],
+        results_length: int,
+        exception: str,
+    ) -> None:
+        if exception:
+            with pytest.raises(AuthenticationError, match=exception):
+                get_data_with_filters(client=icat_user_client, entity_type=entity_type, filters=filters)
+        else:
+            results = get_data_with_filters(client=icat_user_client, entity_type=entity_type, filters=filters)
+            assert len(results) == results_length
 
-    @patch("datagateway_api.src.datagateway_api.icat.helpers.execute_entity_query")
-    @patch(
-        "datagateway_api.src.common.config.Config.config.datagateway_api.use_reader_for_performance.enabled",
-        return_value=True,
+    @pytest.mark.parametrize(
+        ["filters", "results_length", "exception"],
+        [
+            pytest.param(
+                [PythonICATWhereFilter("dataset.id", 7, "eq")],
+                None,
+                "Not authorised to access the dataset.id you have filtered on",
+            ),
+            pytest.param([PythonICATWhereFilter("dataset.id", 6, "eq")], 16, None),
+        ],
     )
-    def test_execute_query_as_reader(self, _, mock_execute_entity_query, icat_client):
-        get_data_with_filters(
-            icat_client,
-            "Datafile",
-            [PythonICATWhereFilter("dataset.id", 3, "eq")],
-        )
-        assert mock_execute_entity_query.call_count == 1
+    def test_open_data(
+        self,
+        enable_reader_open_config: None,
+        enable_reader_permissions: None,
+        associate_data_publication: None,
+        icat_user_client: Client,
+        filters: list[PythonICATWhereFilter],
+        results_length: int,
+        exception: str,
+    ) -> None:
+        if exception:
+            with pytest.raises(AuthenticationError, match=exception):
+                get_data_with_filters(client=icat_user_client, entity_type="Datafile", filters=filters)
+        else:
+            results = get_data_with_filters(client=icat_user_client, entity_type="Datafile", filters=filters)
+            assert len(results) == results_length
 
-        client = mock_execute_entity_query.call_args_list[0][0][0]
-        assert client.getUserName() == "simple/reader"
+    def test_refresh(self, enable_reader_config: None) -> None:
+        client = Client(
+            url=Config.config.datagateway_api.icat_url,
+            checkCert=Config.config.datagateway_api.icat_check_cert,
+        )
+        client._next_refresh = 0
+        ReaderQueryHandler.reader_client = client
+        ReaderQueryHandler.refresh()
+        current_time = time.time()
+        assert current_time + 89 * 60 < ReaderQueryHandler.reader_client._next_refresh < current_time + 90 * 60
+
+    def test_refresh_failure(self, enable_reader_bad_config: None) -> None:
+        client = Client(
+            url=Config.config.datagateway_api.icat_url,
+            checkCert=Config.config.datagateway_api.icat_check_cert,
+        )
+        client._next_refresh = 0
+        ReaderQueryHandler.reader_client = client
+        with pytest.raises(PythonICATError, match="Internal error with reader account configuration"):
+            ReaderQueryHandler.refresh()
+
+    def test_get_investigation_id_failure(self, enable_reader_config: None) -> None:
+        with pytest.raises(expected_exception=MissingRecordError, match="No Dataset found for id=-1"):
+            ReaderQueryHandler.get_investigation_id(dataset_id=-1)

--- a/test/integration/datagateway_api/icat/test_reader_performance.py
+++ b/test/integration/datagateway_api/icat/test_reader_performance.py
@@ -6,7 +6,7 @@ from icat.client import Client
 import pytest
 
 from datagateway_api.src.common.config import APIConfig, Config
-from datagateway_api.src.common.exceptions import AuthenticationError, MissingRecordError, PythonICATError
+from datagateway_api.src.common.exceptions import MissingRecordError, PythonICATError
 from datagateway_api.src.datagateway_api.icat.filters import (
     PythonICATLimitFilter,
     PythonICATOrderFilter,

--- a/test/integration/datagateway_api/icat/test_reader_performance.py
+++ b/test/integration/datagateway_api/icat/test_reader_performance.py
@@ -5,7 +5,7 @@ from typing import Generator
 from icat.client import Client
 import pytest
 
-from datagateway_api.src.common.config import APIConfig, Config, ReaderConfig
+from datagateway_api.src.common.config import APIConfig, Config
 from datagateway_api.src.common.exceptions import AuthenticationError, MissingRecordError, PythonICATError
 from datagateway_api.src.datagateway_api.icat.filters import (
     PythonICATLimitFilter,
@@ -110,26 +110,15 @@ def icat_user_client() -> Client:
 
 @pytest.fixture(scope="function")
 def enable_reader_config() -> Generator[None, None, None]:
-    Config.config.reader = ReaderConfig(mechanism="simple", username="reader", password="readerpw")  # noqa: S106
-    yield
-    Config.config = APIConfig.load()
-
-
-@pytest.fixture(scope="function")
-def enable_reader_open_config() -> Generator[None, None, None]:
-    Config.config.reader = ReaderConfig(  # noqa: S106
-        mechanism="simple",
-        username="reader",
-        password="readerpw",
-        data_publication_type_public="center",
-    )
+    Config.config.datagateway_api.use_reader_for_performance.enabled = True
     yield
     Config.config = APIConfig.load()
 
 
 @pytest.fixture(scope="function")
 def enable_reader_bad_config() -> Generator[None, None, None]:
-    Config.config.reader = ReaderConfig(mechanism="bad", username="reader", password="readerpw")  # noqa: S106
+    Config.config.datagateway_api.use_reader_for_performance.enabled = True
+    Config.config.datagateway_api.use_reader_for_performance.reader_mechanism = "bad"
     yield
     Config.config = APIConfig.load()
 
@@ -193,7 +182,9 @@ class TestReaderPerformance:
         ReaderQueryHandler("Datafile", [])
         reader_client = ReaderQueryHandler.reader_client
         assert isinstance(reader_client, ICATClient)
-        assert reader_client.getUserName() == f"{Config.config.reader.mechanism}/{Config.config.reader.username}"
+        assert reader_client.getUserName() == (
+            f"{Config.config.datagateway_api.use_reader_for_performance.reader_mechanism}/{Config.config.datagateway_api.use_reader_for_performance.reader_username}"
+        )
 
     @pytest.mark.parametrize(
         ["entity_type", "filters", "results_length", "exception"],
@@ -279,7 +270,7 @@ class TestReaderPerformance:
     )
     def test_open_data(
         self,
-        enable_reader_open_config: None,
+        enable_reader_config: None,
         enable_reader_permissions: None,
         associate_data_publication: None,
         icat_user_client: Client,

--- a/util/setup_v11_1_0.py
+++ b/util/setup_v11_1_0.py
@@ -1,0 +1,126 @@
+from argparse import ArgumentParser
+from getpass import getpass
+
+from icat.client import Client
+from icat.entity import Entity
+from icat.exception import ICATObjectExistsError
+from icat.query import Query
+
+from datagateway_api.src.common.config import Config
+
+
+def get_password(password_file: "str | None") -> str:
+    """
+    Load the user's password from `password_file` if provided, otherwise prompt for it.
+
+    Args:
+        password_file (str): Optional path of file containing the user's password.
+
+    Returns:
+        str: The user's password
+    """
+    if password_file is None:
+        return getpass()
+    else:
+        with open(password_file) as f:
+            return f.readline().strip()
+
+
+def create(
+    entity: Entity,
+    allow_existing: bool = False,
+    fetch_existing: bool = False,
+) -> Entity:
+    try:
+        entity.create()
+    except ICATObjectExistsError as e:
+        print(f"Ignoring: {e.message}")
+        if fetch_existing:
+            return entity.client.search(
+                query=Query(
+                    client=entity.client,
+                    entity=entity.BeanName,
+                    conditions={"name": [f"='{entity.name}'"]},  # noqa: B907
+                ),
+            )[0]
+
+    return entity
+
+
+def setup() -> None:
+    parser = ArgumentParser(prog="datagateway_api_setup")
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="https://localhost:8181",
+        help="The url address of the ICAT server.",
+    )
+    parser.add_argument(
+        "-a",
+        "--authenticator",
+        type=str,
+        default="ldap",
+        help="The authentication mechanism to use for ICAT login.",
+    )
+    parser.add_argument(
+        "-u",
+        "--username",
+        type=str,
+        required=True,
+        help="The username used for ICAT login.",
+    )
+    parser.add_argument(
+        "-p",
+        "--password-file",
+        type=str,
+        help=(
+            "Location of file containing password for ICAT login. If not "
+            "provided, the password will need to be provided by prompt."
+        ),
+    )
+    parser.add_argument(
+        "--allow-existing",
+        action="store_true",
+        help=("Iterates over each Entity and if it already exists, suppresses the " "ICATObjectAlreadyExists error."),
+    )
+    args = parser.parse_args()
+
+    client = Client(url=args.url, checkCert=False)
+    client.login(
+        auth=args.authenticator,
+        credentials={
+            "username": args.username,
+            "password": get_password(args.password_file),
+        },
+    )
+
+    (grouping,) = client.search(
+        query=(
+            "SELECT ug.grouping FROM UserGroup ug WHERE ug.user.name = "  # noqa: S608
+            f"{Config.config.datagateway_api.use_reader_for_performance.reader_username!r}"
+        ),
+    )
+
+    entities = [
+        client.new(obj="Rule", crudFlags="R", what="User", grouping=grouping),
+        client.new(obj="Rule", crudFlags="R", what="InvestigationUser", grouping=grouping),
+        client.new(obj="Rule", crudFlags="R", what="InstrumentScientist", grouping=grouping),
+        client.new(obj="Rule", crudFlags="R", what="Instrument", grouping=grouping),
+        client.new(obj="Rule", crudFlags="R", what="InvestigationInstrument", grouping=grouping),
+        client.new(obj="Rule", crudFlags="R", what="Investigation", grouping=grouping),
+        # client.new(obj="Rule", crudFlags="R", what="Dataset", grouping=grouping),  # Should already exist
+        # client.new(obj="Rule", crudFlags="R", what="Datafile", grouping=grouping),  # Should already exist
+        client.new(obj="Rule", crudFlags="R", what="DataPublication", grouping=grouping),
+        client.new(obj="Rule", crudFlags="R", what="DataCollection", grouping=grouping),
+        client.new(obj="Rule", crudFlags="R", what="DataCollectionDataset", grouping=grouping),
+    ]
+
+    if args.allow_existing:
+        for entity in entities:
+            create(entity=entity, allow_existing=args.allow_existing)
+    else:
+        client.createMany(entities)
+
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Description
Open data for Diamond will allow anon/ORCID authenticated users to view Investigations, Datasets and Datafiles associated with DataPublication entities. Previously, the "reader" logic assumed that if you can see an Investigation, you can see the Datasets within it. This is no longer the case, as being able to see an Investigation now could mean it has a non-opened session DOI, or is in an open session/user DOI but only Datasets of DatasetType raw should be visible (enforced by directly associating them via a DataCollection).

To address this, instead of just checking if the user can view the Investigation, do some more sophisticated checks which take into account the new open data logic as well. For performance, the results of this can be cached.

~@patrick-austin TODO: Need to actually benchmark this to check performance is at least comparable to how it was with the old method. Shouldn't merge this PR until I've verified this (so currently a draft), but hopefully it's good as is or with minor changes to make it more performant. May be worth reviewing now or later - either is fine by me.~

Happy enough with the performance, and reverted the breaking config change so this can be tagged as `feat:`. Should be ready for review, but no rush. Will put any breaking changes (config, new API etc.) in a separate branch, branched from this one,

### Specific changes
- ~Refactor `datagateway_api.use_reader_for_performance` to `reader` in the config.~
  - ~Future change will implement a ReadOnly API which will require the same reader account. To follow the same approach as for the dg-api/search-api, intention would be to define a `read_only_api` section to the config and then re-use `reader` (so cannot have it belonging to either "api" config.~
  - Change `password` to `SecretStr`, for secrecy.
- Refactor sub-api extension validations etc. to be compatible with more than two sub-apis (i.e. including a read-only version at a later date)
- Change `create_reader_client` to be a `classmethod` (as it had no dependence on `self`)
- Replace existing reader checks with new `ttl_cache`d `classmethod`s which check if the current user is a reader, or the Dataset is open.
- Update tests to hit new/changed functionality.

## Testing Instructions
Ran through steps below with @joshdimanteto 
  1. Navigate to https://dgwd-dev.diamond.ac.uk/browse/dataPublication?sort=%7B%22publicationDate%22%3A%22desc%22%7D as `anon`, verify that DOI12345-1 appears
  2. Verify no entities appear in the content tab for https://dgwd-dev.diamond.ac.uk/browse/dataPublication/2704028535
  3. Navigate to https://dgwd-dev.diamond.ac.uk/browse/proposal?sort=%7B%22title%22%3A%22asc%22%7D
  4. Verify that [Test visit for DOI testing](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation) does not appear, and displays an empty table if navigated to directly
  5. Verify that [DOI12345-1](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation/2704028018/dataset) does not show any results
  6. Verify that [raw_1](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation/2704028018/dataset/2704028020/datafile) does not show any results
  7. Login as an ORCID user
  8. Navigate to https://dgwd-dev.diamond.ac.uk/browse/dataPublication?sort=%7B%22publicationDate%22%3A%22desc%22%7D, verify that DOI12345-1 appears
  2. Verify Investigation an Dataset `raw_1` appear in the content tab for https://dgwd-dev.diamond.ac.uk/browse/dataPublication/2704028535
  3. Navigate to https://dgwd-dev.diamond.ac.uk/browse/proposal?sort=%7B%22title%22%3A%22asc%22%7D
  4. Verify that [Test visit for DOI testing](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation) does appear, and displays if navigated to
  5. Verify that [DOI12345-1](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation/2704028018/dataset) shows only `raw_1`
  6. Verify that [raw_1](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation/2704028018/dataset/2704028020/datafile) shows rows of Datafiles
  7. Login as a ICAT root user
  8. Navigate to https://dgwd-dev.diamond.ac.uk/browse/dataPublication?sort=%7B%22publicationDate%22%3A%22desc%22%7D, verify that DOI12345-1 appears
  2. Verify Investigation an Dataset `raw_1` appear in the content tab for https://dgwd-dev.diamond.ac.uk/browse/dataPublication/2704028535
  3. Navigate to https://dgwd-dev.diamond.ac.uk/browse/proposal?sort=%7B%22title%22%3A%22asc%22%7D
  4. Verify that [Test visit for DOI testing](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation) does appear, and displays if navigated to
  5. Verify that [DOI12345-1](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation/2704028018/dataset) shows all Datasets: `raw_1` and multiple processing/processed Datasets
  6. Verify that [raw_1](https://dgwd-dev.diamond.ac.uk/browse/proposal/DOI12345/investigation/2704028018/dataset/2704028020/datafile) shows rows of Datafiles

- [x] Review code
- [x] Check GitHub Actions build
- [x] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [x] Review changes to test coverage
- [x] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
  - [x] @patrick-austin put `feat` on any subsequent commits?

