### PR TITLE
Update the release process #557

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -168,26 +168,6 @@ jobs:
       - name: Run Nox black session
         run: nox -s black
 
-  safety:
-    runs-on: ubuntu-24.04
-    name: Dependency Safety
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
-        with:
-          python-version: "3.11"
-          architecture: x64
-      - name: Checkout DataGateway API
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-
-      - name: Install Nox
-        run: pip install nox==2020.8.22
-      - name: Install Poetry
-        run: pip install poetry==1.8.0
-
-      - name: Run Nox safety session
-        run: nox -s safety
-
   generator-script-testing:
     runs-on: ubuntu-24.04
     continue-on-error: true
@@ -433,7 +413,6 @@ jobs:
         tests,
         linting,
         formatting,
-        safety,
         generator-script-testing,
         pip-install-testing,
       ]

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,10 +1,16 @@
 name: CI
 on:
   workflow_dispatch:
+    inputs:
+      push-docker-image-to-harbor:
+        description: "Push Docker Image to Harbor"
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
       - main
+      - develop
 jobs:
   tests:
     runs-on: ubuntu-24.04
@@ -433,6 +439,8 @@ jobs:
       ]
     name: Docker
     runs-on: ubuntu-24.04
+    env:
+      PUSH_DOCKER_IMAGE_TO_HARBOR: ${{ inputs.push-docker-image-to-harbor != null && inputs.push-docker-image-to-harbor || 'false' }}
     steps:
       - name: Check out repo
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v3.5.3
@@ -440,7 +448,7 @@ jobs:
       - name: Login to Harbor
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          registry: harbor.stfc.ac.uk/datagateway
+          registry: ${{ vars.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
@@ -448,12 +456,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
-          images: harbor.stfc.ac.uk/datagateway/datagateway-api
+          images: ${{ vars.HARBOR_URL }}/datagateway-api
 
-      - name: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
+      - name: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,22 +1,43 @@
 name: Release Build
 on:
   push:
-    branches:
-      - main
+    tags: "v*"
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-    name: Release Build
+  docker:
+    # This job builds the Docker image and if successful, it pushes it to Harbor.
+    name: Docker
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.ADMIN_PAT }}
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Python Semantic Release
-        uses: python-semantic-release/python-semantic-release@c1bcfdbb994243ac7cf419365d5894d6bfb2950e # v9.12.0
+      - name: Login to Harbor
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
-          github_token: ${{ secrets.ADMIN_PAT }}
+          registry: ${{ vars.HARBOR_URL }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ vars.HARBOR_URL }}/datagateway-api
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
+
+      - name: Build and push Docker image to Harbor
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ./Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -37,7 +37,6 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
-          file: ./Dockerfile.prod
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -115,9 +115,6 @@ Currently, the following Nox sessions have been created:
 - `lint` - this uses [flake8](https://flake8.pycqa.org/en/latest/) with a number of
   additional plugins (see the included `noxfile.py` to see which plugins are used) to
   lint the code to keep it Pythonic. `.flake8` configures `flake8` and the plugins.
-- `safety` - this uses [safety](https://github.com/pyupio/safety) to check the
-  dependencies (pulled directly from Poetry) for any known vulnerabilities. This session
-  gives the output in a full ASCII style report.
 - `unit_tests` - this uses [pytest](https://docs.pytest.org/en/stable/) to execute the
   automated tests in `test/unit`, tests for Python ICAT, and non Python ICAT specific tests. More details about the tests themselves [here](#running-tests).
 - `integration_tests` - this uses [pytest](https://docs.pytest.org/en/stable/) to execute the

--- a/README.md
+++ b/README.md
@@ -713,9 +713,7 @@ to query DataGateway API.
 # API Versioning
 
 This repository uses semantic versioning as the standard for version number
-incrementing, with the version stored in `pyproject.toml`. There is a GitHub Actions
-workflow (`release-build.yml`) which runs when main is updated (i.e. when a pull
-request is merged). This uses
+incrementing, with the version stored in `pyproject.toml`. We uses
 [python-semantic-release](https://github.com/relekang/python-semantic-release) to
 determine whether a release needs to be made, and if so, whether a major, minor or patch
 version bump should be made. This decision is made based on commit message content.
@@ -759,8 +757,7 @@ main. When the version is bumped, a GitHub tag and release is made which contain
 source code and the built versions of the API (sdist and wheel).
 
 To check how the version number will be impacted before merging a pull request, use the
-following command to show the version which will be made when the GitHub Actions release
-build job runs (upon merging a branch/PR):
+following command to show the version:
 
 ```bash
 poetry run semantic-release print-version

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 # Separating Black away from the rest of the sessions
-nox.options.sessions = "lint", "safety", "tests"
+nox.options.sessions = "lint", "tests"
 code_locations = "datagateway_api", "test", "util", "noxfile.py"
 
 
@@ -18,18 +18,6 @@ def lint(session):
     args = session.posargs or code_locations
     session.run("poetry", "install", "--only=dev", external=True)
     session.run("flake8", *args)
-
-
-@nox.session(reuse_venv=True)
-def safety(session):
-    session.install("safety")
-    # Ignore vulnerabilities as the patched versions of dependencies that they
-    # relate to don't support Python 3.6 which is still required for production
-    session.run(
-        "safety",
-        "check",
-        "--full-report",
-    )
 
 
 @nox.session(python=["3.11"], reuse_venv=True)

--- a/poetry.lock
+++ b/poetry.lock
@@ -659,26 +659,6 @@ files = [
 ]
 
 [[package]]
-name = "dparse"
-version = "0.6.4"
-description = "A parser for Python dependency files"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "dparse-0.6.4-py3-none-any.whl", hash = "sha256:fbab4d50d54d0e739fbb4dedfc3d92771003a5b9aa8545ca7a7045e3b174af57"},
-    {file = "dparse-0.6.4.tar.gz", hash = "sha256:90b29c39e3edc36c6284c82c4132648eaf28a01863eb3c231c2512196132201a"},
-]
-
-[package.dependencies]
-packaging = "*"
-
-[package.extras]
-all = ["pipenv", "poetry", "pyyaml"]
-conda = ["pyyaml"]
-pipenv = ["pipenv"]
-poetry = ["poetry"]
-
-[[package]]
 name = "email-validator"
 version = "2.3.0"
 description = "A robust email address syntax and deliverability validation library."
@@ -2650,46 +2630,6 @@ files = [
 ]
 
 [[package]]
-name = "ruamel-yaml"
-version = "0.19.1"
-description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93"},
-    {file = "ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993"},
-]
-
-[package.extras]
-docs = ["mercurial (>5.7)", "ryd"]
-jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
-libyaml = ["ruamel.yaml.clibz (>=0.3.7)"]
-oldlibyaml = ["ruamel.yaml.clib"]
-
-[[package]]
-name = "safety"
-version = "2.3.4"
-description = "Checks installed dependencies for known vulnerabilities and licenses."
-optional = false
-python-versions = "*"
-files = [
-    {file = "safety-2.3.4-py3-none-any.whl", hash = "sha256:6224dcd9b20986a2b2c5e7acfdfba6bca42bb11b2783b24ed04f32317e5167ea"},
-    {file = "safety-2.3.4.tar.gz", hash = "sha256:b9e74e794e82f54d11f4091c5d820c4d2d81de9f953bf0b4f33ac8bc402ae72c"},
-]
-
-[package.dependencies]
-Click = ">=8.0.2"
-dparse = ">=0.6.2"
-packaging = ">=21.0"
-requests = "*"
-"ruamel.yaml" = ">=0.17.21"
-setuptools = ">=19.3"
-
-[package.extras]
-github = ["jinja2 (>=3.1.0)", "pygithub (>=1.43.3)"]
-gitlab = ["python-gitlab (>=1.3.0)"]
-
-[[package]]
 name = "secretstorage"
 version = "3.5.0"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -3421,4 +3361,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a0274b21913d47aafa5bb48f254dc3d0620a63125eb6042f30a69861782852b7"
+content-hash = "f000646a48ff174756636721cd79f21cad42daa06fdb48a7a58cfa4200bbdbe3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ pytest-cov = "^5.0.0"
 pytest-icdiff = "^0.9"
 python-semantic-release = "^7.19.2"
 coverage-conditional-plugin = "^0.9.0"
-safety = "^2.2.0"
 
 [tool.poetry.scripts]
 


### PR DESCRIPTION

## Description
see #557 , #555

- Remove safety, the plan is to use dependabot for vulnerabilities  
- Change release process to manual instead of automatic. This is following what has been use for IMS.

1.  tags should be pushed to harbor when a release has been made 
2.  docker image for branches can be optionally pushed to harbor from the actions tag 
3. https://github.com/ral-facilities/datagateway-api/wiki/Release-Process 

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
closes #557 ,#555
