### PR TITLE
Fix/swagger include query param #560

### DIFF
--- a/datagateway_api/src/datagateway_api/routers/entity.py
+++ b/datagateway_api/src/datagateway_api/routers/entity.py
@@ -109,7 +109,7 @@ OrderQuery = Query(
     title="ORDER_FILTER",
     description=("Apply order filters to the query. Given a field and direction, order the returned entities."),
     json_schema_extra={"type": "array", "items": {"type": "string", "default": ""}},
-    openapi_examples={"asc": {"value": ["id asc"]}, "desc": {"value": ["id desc"]}},
+    openapi_examples={"asc": {"value": ['"id asc"']}, "desc": {"value": ['"id desc"']}},
 )
 LimitQuery = Query(
     default=None,
@@ -136,41 +136,10 @@ IncludeQuery = Query(
     " related entities, include them in the results. Only one include parameter"
     " is allowed.",
     json_schema_extra={
-        "oneOf": [
-            {"type": "string"},
-            {
-                "type": "array",
-                "items": {
-                    "oneOf": [
-                        {"type": "string"},
-                        {
-                            "type": "object",
-                            "additionalProperties": {
-                                "oneOf": [
-                                    {"type": "string"},
-                                    {
-                                        "type": "array",
-                                        "items": [{"type": "string"}],
-                                    },
-                                ],
-                            },
-                        },
-                    ],
-                },
-            },
-            {
-                "type": "object",
-                "additionalProperties": {
-                    "oneOf": [
-                        {"type": "string"},
-                        {"type": "array", "items": [{"type": "string"}]},
-                    ],
-                },
-            },
-        ],
+        "type": "string",
     },
     openapi_examples={
-        "single": {"value": "RELATED_COLUMN"},
+        "single": {"value": '"RELATED_COLUMN"'},
         "array": {"value": ["RELATED_COLUMN_1", "RELATED_COLUMN_2"]},
         "multi-level": {
             "value": {"RELATED_COLUMN": "RELATED_COLUMN_RELATED_COLUMN"},


### PR DESCRIPTION
## Description
Swagger UI was incorrectly serialising the `include` query parameter when
defined with a complex `oneOf` schema (string, array, object). This caused:

- object values to be flattened into query params
- arrays to be split into multiple parameters
- nested structures to break entirely

Although the backend supports these formats correctly, the Swagger UI
could not represent or send them properly.

Fix:
- Force `include` to be treated as a string in OpenAPI using:
  - schema.type=string
- Convert examples to JSON strings so they are transmitted correctly
- Fix string examples 

Result:
- Swagger now sends `include` as a single encoded JSON value
- All supported formats work consistently
- Backend logic unchanged

## Testing Instructions
For the GET investigations endpoint:

example 1: 
order : "id asc"
skip : 0
limit: 50
include:  {"investigationInstruments":"instrument"}

example 2: 
order : "id asc"
skip : 0
limit: 50
include: "investigationInstruments"

example 3: 
order : "id asc"
skip : 0
limit: 50
include: ["investigationInstruments", "publications"]

example 3: 
order : "id asc"
skip : 0
limit: 50
include: ["publications", {"investigationInstruments":"instrument"}]


example 5: 
order : "id asc"
skip : 0
limit: 50
include:  {"investigationInstruments":["instrument","investigation"]}

example 6: 
order : "id asc"
skip : 0
limit: 50
include:  {"investigationInstruments":{"instrument":"facility"}}



- [x] Review code
- [x] Check GitHub Actions build
- [x] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [x] Review changes to test coverage
- [x] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}

## Agile Board Tracking
closes #560
