### PR TITLE
chore(deps): group dependent bot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,76 @@
 version: 2
 updates:
+  # Maintain Dockerfile dependencies on the `develop` branch
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+    target-branch: "develop"
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
 
-  # Maintain dependencies for GitHub Actions
+  # Maintain Dockerfile dependencies on the `main` branch
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+    target-branch: "main"
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+
+  # Maintain GitHub Actions dependencies on the `develop` branch
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates every week
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    target-branch: "develop"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Maintain GitHub Actions dependencies on the `main` branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Maintain uv dependencies on the `develop` branch
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    target-branch: "develop"
+    groups:
+      uv:
+        patterns:
+          - "*"
+        # Dependabot can check the lockfile, but cannot update these detected in pyproject.toml. As updates are grouped
+        # this causes all updates within the group to be skipped.
+        # E.g. `Skipping change to group uv in directory /: Previous version was not provided for: 'uv-build'`
+        exclude-patterns:
+          - "uv-build"
+          - "datagateway-api"


### PR DESCRIPTION
## Description
Configure Dependabot to manage Docker, GitHub Actions, and uv dependencies across the develop and main branches. Updates are scheduled regularly with a 7-day cooldown. GitHub Actions and uv dependencies are grouped into single PRs to simplify review and maintenance.

Quoted from IMS repo


_We use Renovates default of 3 days for npm packages on the frontend, here it seems for pip 7 days is generally considered preferable, so went for that. Doesnt resolve supply chain attacks, but relies on the community to notice something is wrong which typically occurs within a short timespace after packages are released._


## Testing Instructions

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?


