### PR TITLE
only login to harbor when pushing image

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -408,6 +408,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v3.5.3
 
       - name: Login to Harbor
+        if: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) }}
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ vars.HARBOR_URL }}


### PR DESCRIPTION
## Description
Only log in to Harbor when pushing images. This avoids failures in the Docker job caused by Dependabot, which does not have access to secrets. Since images are only pushed manually, the login step is only required when the relevant environment variable is set.

## Testing Instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?
- [ ] {more steps here}


