### PR TITLE
fix(ci): add explicit GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
       - develop
+
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Description
Add workflow-level permissions block with contents: read to satisfy CodeQL security recommendations.

## Testing Instructions


- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

