### PR TITLE
Handle non-entity fields that are present in includes #626

### DIFF
--- a/datagateway_api/datagateway_api/icat/query.py
+++ b/datagateway_api/datagateway_api/icat/query.py
@@ -161,9 +161,8 @@ class ICATQuery:
         # Verifying that `includes` only has fields which are related to the entity
         include_set = (entity.InstRel | entity.InstMRel) & set(includes)
         for key in entity.InstAttr | entity.MetaAttr | include_set:
+            entity_data = getattr(entity, key)
             if key in includes:
-
-                target = getattr(entity, key)
                 # Copy and remove don't return values so must be done separately
                 includes_copy = includes.copy()
                 try:
@@ -173,23 +172,26 @@ class ICATQuery:
                         "Key couldn't be found to remove from include list, this could"
                         " cause an issue further on in the request",
                     )
-                if isinstance(target, Entity):
-                    d[key] = self.entity_to_dict(target, includes_copy)
+                if isinstance(entity_data, Entity):
+                    d[key] = self.entity_to_dict(entity_data, includes_copy)
+                    continue
                 # Related fields with one-many relationships are stored as EntityLists
-                elif isinstance(target, EntityList):
+                elif isinstance(entity_data, EntityList):
                     d[key] = []
-                    for e in target:
+                    for e in entity_data:
                         d[key].append(self.entity_to_dict(e, includes_copy))
+                    continue
+                # May not actually be an Entity(ies), e.g. type may be in the includes but is also sometimes a str field
+                # Fall through to usual behaviour below
 
             # Add actual piece of data to the dictionary
-            else:
-                entity_data = getattr(entity, key)
-                # Convert datetime objects to strings ready to be outputted as JSON
-                if isinstance(entity_data, datetime):
-                    # Remove timezone data which isn't utilised in ICAT
-                    entity_data = DateHandler.datetime_object_to_str(entity_data)
+            # Convert datetime objects to strings ready to be outputted as JSON
+            if isinstance(entity_data, datetime):
+                # Remove timezone data which isn't utilised in ICAT
+                entity_data = DateHandler.datetime_object_to_str(entity_data)
 
-                d[key] = entity_data
+            d[key] = entity_data
+
         return d
 
     def flatten_query_included_fields(self, includes):


### PR DESCRIPTION
This PR will close #626

## Description
As described on issue.

## Testing Instructions
If the includes from the issue are used on an investigation query where `Instrument.type` is set, you should now see it returned (just like it would be without the mention of `type`).

I do have an automated test which would test this, coming in another PR soon (TM).

- [ ] Review code
- [ ] Check GitHub Actions build
- [ ] If `icatdb Generator Script Consistency Test` CI job fails, is this because of a deliberate change made to the script to change generated data (which isn't actually a problem) or is here an underlying issue with the changes made?
- [ ] Review changes to test coverage
- [ ] Does this change mean a new patch, minor or major version should be made? If so, does one of the commit messages feature `fix:`, `feat:` or `BREAKING CHANGE:` so a release is automatically made via GitHub Actions upon merge?

## Agile Board Tracking
Connect to #626
